### PR TITLE
fix: avoid ipywidget interaction fix #56

### DIFF
--- a/style/leaflet.css
+++ b/style/leaflet.css
@@ -1,6 +1,4 @@
 .leaflet-container {
-  height: 300px;
-  width: 100%;
   z-index: 0;
 }
 .leaflet-bar a.leaflet-disabled {


### PR DESCRIPTION
`leaflet-container` CSS class should not been overridden
and map height is yet managed by `jp-EodagWidget-map`
CSS class.