### PR TITLE
fix: set leaflet container size fix #59

### DIFF
--- a/style/leaflet.css
+++ b/style/leaflet.css
@@ -1,4 +1,6 @@
 .leaflet-container {
+  height: 100%;
+  width: 100%;
   z-index: 0;
 }
 .leaflet-bar a.leaflet-disabled {


### PR DESCRIPTION
Set a size for `leaflet-container` CSS class so that leaflet map fills its container div.