### PR TITLE
fix: update labextension for eodag 2.11

### DIFF
--- a/eodag_labextension/handlers.py
+++ b/eodag_labextension/handlers.py
@@ -8,14 +8,11 @@ import json
 import re
 
 import tornado
-from eodag.rest.server import app, run_swagger, stac_api_config
 from eodag.rest.utils import eodag_api, get_product_types, search_products
 from eodag.utils import parse_qs
 from eodag.utils.exceptions import AuthenticationError, NoMatchingProductType, UnsupportedProductType, ValidationError
 from jupyter_server.base.handlers import APIHandler
 from jupyter_server.utils import url_path_join
-from tornado.web import FallbackHandler
-from tornado.wsgi import WSGIContainer
 
 
 class ProductTypeHandler(APIHandler):
@@ -99,25 +96,6 @@ class SearchHandler(APIHandler):
         self.finish(response)
 
 
-class PrefixMiddleware(object):
-    """Appends a prefix to the WSGI container around Flask app"""
-
-    def __init__(self, app, prefix=""):
-        """Class init method"""
-        self.app = app
-        self.prefix = prefix
-
-    def __call__(self, environ, start_response):
-        """Call method"""
-        if environ["PATH_INFO"].startswith(self.prefix):
-            environ["PATH_INFO"] = environ["PATH_INFO"][len(self.prefix) :]
-            environ["SCRIPT_NAME"] = self.prefix
-            return self.app(environ, start_response)
-        else:
-            start_response("404", [("Content-Type", "text/plain")])
-            return ["This url does not belong to the app.".encode()]
-
-
 class MethodAndPathMatch(tornado.routing.PathMatches):
     """Wrapper around `tornado.routing.PathMatches` adding http method matching"""
 
@@ -142,35 +120,14 @@ def setup_handlers(web_app, url_path):
 
     # matching patterns
     host_pattern = ".*$"
-    home_pattern = url_path_join(base_url, url_path, r"?/")
-    eodag_serve_services_pattern = url_path_join(
-        base_url, url_path, r"(api|service-doc.*|service-static.*|conformance|collections.*|search.*)"
-    )
     product_types_pattern = url_path_join(base_url, url_path, "product-types")
     guess_product_types_pattern = url_path_join(base_url, url_path, "guess-product-type")
     search_pattern = url_path_join(base_url, url_path, r"(?P<product_type>[\w-]+)")
 
-    # WSGI container around eodag-serve app
-    app.wsgi_app = PrefixMiddleware(app.wsgi_app, prefix=url_path_join(base_url, url_path))
-    eodag_serve_container = WSGIContainer(app)
-
-    # flasgger conf update with url prefix
-    stac_api_config["info"]["description"] = stac_api_config["info"]["description"].replace(
-        "(/collections", "(/%s" % url_path_join(url_path, "collections")
-    )
-    stac_api_new_paths = {f"/{url_path}{path}": path_conf for path, path_conf in stac_api_config["paths"].items()}
-    stac_api_config["paths"] = stac_api_new_paths
-
-    # run flasgger doc
-    run_swagger(app=app, config=stac_api_config, merge=True)
-
     # handlers added for each pattern
     handlers = [
-        (home_pattern, FallbackHandler, dict(fallback=eodag_serve_container)),
-        (eodag_serve_services_pattern, FallbackHandler, dict(fallback=eodag_serve_container)),
         (product_types_pattern, ProductTypeHandler),
         (guess_product_types_pattern, GuessProductTypeHandler),
         (MethodAndPathMatch("POST", search_pattern), SearchHandler),
-        (MethodAndPathMatch("GET", search_pattern), FallbackHandler, dict(fallback=eodag_serve_container)),
     ]
     web_app.add_handlers(host_pattern, handlers)

--- a/eodag_labextension/handlers.py
+++ b/eodag_labextension/handlers.py
@@ -68,6 +68,11 @@ class SearchHandler(APIHandler):
 
         arguments = json.loads(self.request.body)
 
+        # move geom to intersects parameter
+        geom = arguments.pop("geom", None)
+        if geom:
+            arguments["intersects"] = geom
+
         try:
             response = search_products(product_type, arguments, stac_formatted=False)
         except ValidationError as e:


### PR DESCRIPTION
- send geometry as `intersects` parameter to eodag
- remove exposed eodag REST API

Fixes #119 