### PR TITLE
fix: update eodag.rest imports

### DIFF
--- a/eodag_labextension/handlers.py
+++ b/eodag_labextension/handlers.py
@@ -11,7 +11,6 @@ import orjson
 import tornado
 from eodag import EODataAccessGateway, SearchResult
 from eodag.api.core import DEFAULT_ITEMS_PER_PAGE, DEFAULT_PAGE
-from eodag.rest.utils import get_datetime
 from eodag.utils import parse_qs
 from eodag.utils.exceptions import (
     AuthenticationError,
@@ -20,6 +19,7 @@ from eodag.utils.exceptions import (
     UnsupportedProvider,
     ValidationError,
 )
+from eodag.utils.rest import get_datetime
 from jupyter_server.base.handlers import APIHandler
 from jupyter_server.utils import url_path_join
 from shapely.geometry import shape

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup_args = dict(
         "jupyterlab~=3.0",
         "tornado>=6.0.3,<7.0.0",
         "notebook>=6.0.3,<7.0.0",
-        "eodag[notebook]>=2.8.0",
+        "eodag[notebook] @ git+https://github.com/CS-SI/eodag.git@develop",
         "orjson",
     ],
     extras_require={"dev": ["black", "pre-commit", "pytest", "shapely"]},


### PR DESCRIPTION
Updates `eodag.rest` imports to `eodag.utils.rest` that won't need `eodag[server]` installed, introduced with incoming `eodag v3.0`

Needs https://github.com/CS-SI/eodag/pull/1115

Also updates `guess-product-type` handler following https://github.com/CS-SI/eodag/pull/909