### PR TITLE
refactor: adapt to eodag v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v1
         with:
-          node-version: '16.x'
+          node-version: '18.x'
       - name: Install Python
         uses: actions/setup-python@v2
         with:

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ setup_logging(1) # 0: nothing, 1: only progress bars, 2: INFO, 3: DEBUG
 
 dag = EODataAccessGateway()
 geometry = "POLYGON ((0.550136 43.005451, 0.550136 44.151469, 2.572104 44.151469, 2.572104 43.005451, 0.550136 43.005451))"
-search_results, total_count = dag.search(
+search_results = dag.search(
   productType="S2_MSI_L1C",
   geom=geometry,
   start="2021-08-01",

--- a/eodag_labextension/handlers.py
+++ b/eodag_labextension/handlers.py
@@ -215,7 +215,7 @@ class SearchHandler(APIHandler):
         arguments = dict((k, v) for k, v in arguments.items() if v is not None)
 
         try:
-            products, total = eodag_api.search(productType=product_type, **arguments)
+            products = eodag_api.search(productType=product_type, count=True, **arguments)
         except ValidationError as e:
             self.set_status(400)
             self.finish({"error": e.message})
@@ -243,7 +243,7 @@ class SearchHandler(APIHandler):
                 "properties": {
                     "page": int(arguments.get("page", DEFAULT_PAGE)),
                     "itemsPerPage": DEFAULT_ITEMS_PER_PAGE,
-                    "totalResults": total,
+                    "totalResults": products.number_matched,
                 }
             }
         )

--- a/notebooks/user_manual.ipynb
+++ b/notebooks/user_manual.ipynb
@@ -151,7 +151,7 @@
     "\n",
     "dag = EODataAccessGateway()\n",
     "geometry = \"POLYGON ((0.550136 43.005451, 0.550136 44.151469, 2.572104 44.151469, 2.572104 43.005451, 0.550136 43.005451))\"\n",
-    "search_results, total_count = dag.search(\n",
+    "search_results = dag.search(\n",
     "  productType=\"S2_MSI_L1C\",\n",
     "  geom=geometry,\n",
     "  start=\"2022-11-01\",\n",

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup_args = dict(
         "jupyterlab~=3.0",
         "tornado>=6.0.3,<7.0.0",
         "notebook>=6.0.3,<7.0.0",
-        "eodag[notebook] @ git+https://github.com/CS-SI/eodag.git@develop",
+        "eodag[notebook]>=3.0.0b1",
         "orjson",
     ],
     extras_require={

--- a/src/CodeGenerator.ts
+++ b/src/CodeGenerator.ts
@@ -45,7 +45,7 @@ ${standardMessage}`
 geometry = "${geojsonToWKT(geometry)}"`;
   }
   code += `
-search_results, total_count = dag.search(`;
+search_results = dag.search(`;
   if (provider) {
     code += `
     provider="${provider}",`;

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -149,7 +149,7 @@ class TestEodagLabExtensionHandler(AsyncHTTPTestCase):
     def test_post_not_found(self):
         self.fetch_results_error("/eodag/foo/bar", 404, method="POST", body=json.dumps({}))
 
-    @mock.patch("eodag.api.core.EODataAccessGateway.search", autospec=True, return_value=(SearchResult([]), 0))
+    @mock.patch("eodag.api.core.EODataAccessGateway.search", autospec=True, return_value=SearchResult([], 0))
     def test_search(self, mock_search):
         geom_dict = {
             "type": "Polygon",
@@ -181,6 +181,7 @@ class TestEodagLabExtensionHandler(AsyncHTTPTestCase):
             cloudCover=50,
             foo="bar",
             provider="cop_dataspace",
+            count=True,
         )
         self.assertDictEqual(
             result,
@@ -205,6 +206,7 @@ class TestEodagLabExtensionHandler(AsyncHTTPTestCase):
         mock_search.assert_called_once_with(
             mock.ANY,
             productType="S2_MSI_L1C",
+            count=True,
         )
 
         # date error


### PR DESCRIPTION
Adapt to eodag v3
- search method returns only a `SearchResult` instead of a tuple
- total count accessible through `SearchResult.number_matched`

Also update github action `build` to node v18, following an incompatibility with `playright v1.45.0` that is used by `jupyterlab.browser_check`