### PR TITLE
build: pinned ipyleaflet

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,9 @@ setup_args = dict(
         "notebook>=6.0.3,<7.0.0",
         "eodag[notebook]>=3.0.0b1",
         "orjson",
+        # ipyleaflet is not needed, but versions >= 0.17.4 will make the labextension crash
+        # try removing this dependency when updating leaflet and/or jupyterlab
+        "ipyleaflet<0.17.4",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
Added `ipyleaflet` as dependency even if it was not needed:
If it is installed with `version >= 0.17.4`, it  will make the labextension crash (geometry draw toolbox disappear).

Try removing this dependency when updating `leaflet` and/or `jupyterlab`