### PR TITLE
fix: raise errors from search handler

### DIFF
--- a/eodag_labextension/handlers.py
+++ b/eodag_labextension/handlers.py
@@ -210,6 +210,8 @@ class SearchHandler(APIHandler):
         provider = arguments.pop("provider", None)
         if provider and provider != "null":
             arguments["provider"] = provider
+            # only raise error if provider selected, if not enable search fallback
+            arguments["raise_errors"] = True
 
         # We remove potential None values to use the default values of the search method
         arguments = dict((k, v) for k, v in arguments.items() if v is not None)

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -30,7 +30,7 @@ export async function requestAPI<T>(
   try {
     response = await ServerConnection.makeRequest(requestUrl, init, settings);
   } catch (error) {
-    throw new ServerConnection.NetworkError(error);
+    throw new ServerConnection.NetworkError(error as TypeError);
   }
 
   let data: any = await response.text();

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -182,6 +182,7 @@ class TestEodagLabExtensionHandler(AsyncHTTPTestCase):
             foo="bar",
             provider="cop_dataspace",
             count=True,
+            raise_errors=True,
         )
         self.assertDictEqual(
             result,


### PR DESCRIPTION
Raise errors from `search` handler when specifying a `provider`. Do not change when no provider is et to enable search fallback mechanism