### PR TITLE
fix(modal): fix multiple display bugs in modal

### DIFF
--- a/src/ModalComponent.tsx
+++ b/src/ModalComponent.tsx
@@ -15,6 +15,9 @@ import DescriptionProductComponent from './DescriptionProductComponent';
 import { Tooltip, PlacesType, VariantType } from 'react-tooltip';
 
 const customStyles: Styles = {
+  overlay: {
+    zIndex: 10
+  },
   content: {
     top: '0px',
     left: '0px',
@@ -22,7 +25,7 @@ const customStyles: Styles = {
     bottom: 'auto',
     height: 'auto',
     width: '100%',
-    zIndex: 4,
+    zIndex: 10,
     marginRight: '0',
     padding: '0',
     borderRadius: 'none',

--- a/style/base.css
+++ b/style/base.css
@@ -573,6 +573,10 @@ section button .jp-EodagWidget-additionnalParameters-addbutton svg,
   color: white;
 }
 
+.jp-EodagWidget-appbar p {
+  margin: 0;
+}
+
 .jp-Eodag-tooltip {
   max-width: 200px;
   padding: 8px 16px !important;

--- a/style/base.css
+++ b/style/base.css
@@ -7,6 +7,10 @@
   --base-font-size: 14px;
 }
 
+p {
+  margin: unset;
+}
+
 .jp-EodagWidget {
   display: flex;
   flex-direction: column;
@@ -571,10 +575,6 @@ section button .jp-EodagWidget-additionnalParameters-addbutton svg,
   padding: 12px 10px;
   font-size: 20px;
   color: white;
-}
-
-.jp-EodagWidget-appbar p {
-  margin: 0;
 }
 
 .jp-Eodag-tooltip {


### PR DESCRIPTION
### Context
Modal component used to have two display issues :
1 - An empty white div appeared above the modal appbar
2 - The same modal appbar used to have a height too big, and it shrinked the footer, not allowing the "Generate Code" button to show.

### Changes
1 - Increase the zIndex of the modal overlay for the white div to show behind the modal appbar.
1.5 - Increase the zIndex of the content to be sure nothing gets in front of the content either.
2 - Remove the unwanted margin of the "p" element in the appbar title.

### How to test
- [x] 1. Open the "Search results" modal with any parameters.
- [x] 2. Check that there is no white bar in the place of the modal appbar
- [x] 3. Check that the "Generate code" button can be seen and that the "Search results" element has the correct height.

### Link
Ticket : #176 


![image](https://github.com/user-attachments/assets/ca70551a-bd56-4995-b557-31ea5e3b9d56)

Edit: 

Add a "margin: unset" to all "p" elements in the application, because the issue seems to be on every element.
It might fix some other issues.
