### PR TITLE
feat(main form): async handlers and loading state that disables the selects when fetchs are loading

### DIFF
--- a/src/Autocomplete.tsx
+++ b/src/Autocomplete.tsx
@@ -90,6 +90,7 @@ interface IProps {
   value: string;
   handleChange: any;
   label: string;
+  disabled?: boolean;
   placeholder?: string;
   loadSuggestions?: (inputValue: string) => Promise<IOptionTypeBase[]>;
 }
@@ -102,6 +103,7 @@ class IntegrationReactSelect extends React.Component<IProps> {
       value,
       handleChange,
       placeholder,
+      disabled = false,
       loadSuggestions
     } = this.props;
     let currentValue: OptionTypeBase | null;
@@ -127,6 +129,7 @@ class IntegrationReactSelect extends React.Component<IProps> {
               components={listcomponents}
               value={currentValue}
               onChange={handleChange}
+              isDisabled={disabled}
               placeholder={placeholder}
               isClearable
             />

--- a/src/formComponent/FormComponent.tsx
+++ b/src/formComponent/FormComponent.tsx
@@ -84,6 +84,8 @@ export const FormComponent: FC<IProps> = ({
   const [additionalParameters, setAdditionalParameters] =
     useState<boolean>(true);
   const [optionalParams, setOptionalParams] = useState<IOptionType[]>([]);
+  const { fetchProvider, fetchProvidersLoading } = useFetchProvider();
+  const { fetchProduct, fetchProductLoading } = useFetchProduct();
 
   const formInput = useForm<IFormInput>({
     defaultValues: {
@@ -114,7 +116,6 @@ export const FormComponent: FC<IProps> = ({
 
   useEffect(() => {
     const fetchData = async () => {
-      const fetchProduct = useFetchProduct();
       const productList = await fetchProduct(providerValue);
       setProductTypes(productList);
       if (reloadIndicator) {
@@ -126,7 +127,6 @@ export const FormComponent: FC<IProps> = ({
 
   useEffect(() => {
     const fetchData = async () => {
-      const fetchProvider = useFetchProvider();
       const providerList = await fetchProvider(productTypeValue);
 
       setProviders(providerList);
@@ -178,9 +178,6 @@ export const FormComponent: FC<IProps> = ({
         });
     }
   };
-
-  const loadProductTypesSuggestions = useFetchProduct();
-  const loadProviderSuggestions = useFetchProvider();
 
   const fetchParameters = async (
     query_params: { [key: string]: any } | undefined = undefined
@@ -326,8 +323,9 @@ export const FormComponent: FC<IProps> = ({
                   placeholder="Any"
                   suggestions={providers ? providers : []}
                   value={value ?? null}
+                  disabled={fetchProvidersLoading}
                   loadSuggestions={(inputValue: string) =>
-                    loadProviderSuggestions(null, inputValue)
+                    fetchProvider(null, inputValue)
                   }
                   handleChange={(e: IOptionTypeBase | null) => {
                     onChange(e === null ? null : e.value);
@@ -346,8 +344,9 @@ export const FormComponent: FC<IProps> = ({
                   suggestions={productTypes ? productTypes : []}
                   placeholder="S2_..."
                   value={value ?? null}
+                  disabled={fetchProductLoading}
                   loadSuggestions={(inputValue: string) =>
-                    loadProductTypesSuggestions(providerValue, inputValue)
+                    fetchProduct(providerValue, inputValue)
                   }
                   handleChange={(e: IOptionTypeBase | null) => {
                     if (e === null) {

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -12,7 +12,8 @@ from eodag.api.core import DEFAULT_ITEMS_PER_PAGE
 from eodag.types.queryables import QueryablesDict
 from notebook.notebookapp import NotebookApp
 from shapely.geometry import shape
-from tornado.testing import AsyncHTTPTestCase
+from tornado.httpclient import HTTPClientError
+from tornado.testing import AsyncHTTPTestCase, gen_test
 from tornado.web import authenticated
 
 from eodag_labextension import __version__ as labextension_version
@@ -42,6 +43,21 @@ class TestEodagLabExtensionHandler(AsyncHTTPTestCase):
                 os.environ.pop(k)
         os.environ.update(cls.eodag_env_backup)
 
+    def setUp(self):
+        super().setUp()
+        self.patcher_xsrf = mock.patch.object(APIHandler, "check_xsrf_cookie", return_value=MockUser())
+        self.patcher_user = mock.patch.object(APIHandler, "get_current_user", return_value=MockUser())
+        self.patcher_auth = mock.patch.object(authenticated, "__call__", return_value=lambda x: x)
+        self.mock_xsrf = self.patcher_xsrf.start()
+        self.mock_user = self.patcher_user.start()
+        self.mock_auth = self.patcher_auth.start()
+
+    def tearDown(self):
+        super().tearDown()
+        self.patcher_xsrf.stop()
+        self.patcher_user.stop()
+        self.patcher_auth.stop()
+
     def get_app(self):
         # Create a new NotebookApp instance
         app = NotebookApp()
@@ -52,119 +68,114 @@ class TestEodagLabExtensionHandler(AsyncHTTPTestCase):
 
         return app.web_app
 
-    @mock.patch.object(APIHandler, "check_xsrf_cookie", return_value=MockUser())
-    @mock.patch.object(APIHandler, "get_current_user", return_value=MockUser())
-    @mock.patch.object(authenticated, "__call__", return_value=lambda x: x)
-    def fetch_results(self, url, mock_auth, mock_user, mock_xsrf, **kwargs):
+    async def fetch_results(self, url, **kwargs):
         """Check that request status is 200 and return the json result as dict"""
-        response = self.fetch(url, **kwargs)
+        response = await self.http_client.fetch(self.get_url(url), **kwargs)
         self.assertEqual(response.code, 200)
         return json.loads(response.body.decode("utf-8"))
 
-    @mock.patch.object(APIHandler, "check_xsrf_cookie", return_value=MockUser())
-    @mock.patch.object(APIHandler, "get_current_user", return_value=MockUser())
-    @mock.patch.object(authenticated, "__call__", return_value=lambda x: x)
-    def fetch_results_error(
-        self,
-        url,
-        error_code=None,
-        mock_auth=None,
-        mock_user=None,
-        mock_xsrf=None,
-        **kwargs,
-    ):
+    async def fetch_results_error(self, url, error_code=None, **kwargs):
         """Check that request returns a 400 error"""
-        response = self.fetch(url, **kwargs)
-        self.assertNotEqual(response.code, 200)
-        if error_code:
-            self.assertEqual(response.code, error_code)
-        return json.loads(response.body.decode("utf-8"))
+        # with self.assertRaises(HTTPClientError) as err:
+        try:
+            response = await self.http_client.fetch(self.get_url(url), **kwargs)
+        except HTTPClientError as err:
+            if error_code:
+                self.assertEqual(err.code, error_code)
+        else:
+            self.fail(f"Expected {response} to raise HTTP {error_code}")
 
-    def test_product_types(self):
+    @gen_test
+    async def test_product_types(self):
         # all product types
-        results = self.fetch_results("/eodag/product-types")
+        results = await self.fetch_results("/eodag/product-types")
         self.assertIn("S2_MSI_L1C", [pt["ID"] for pt in results])
 
         # single provider product types
-        less_results = self.fetch_results("/eodag/product-types?provider=peps")
+        less_results = await self.fetch_results("/eodag/product-types?provider=peps")
         self.assertGreater(len(less_results), 0)
         self.assertLess(len(less_results), len(results))
 
         # unknown provider
-        self.fetch_results_error("/eodag/product-types?provider=foo", 400)
+        await self.fetch_results_error("/eodag/product-types?provider=foo", 400)
 
-    def test_providers(self):
+    @gen_test
+    async def test_providers(self):
         # all providers
-        results = self.fetch_results("/eodag/providers")
+        results = await self.fetch_results("/eodag/providers")
         self.assertIn("peps", [res["provider"] for res in results])
 
-        less_results = self.fetch_results("/eodag/providers?product_type=S2_MSI_L1C")
+        less_results = await self.fetch_results("/eodag/providers?product_type=S2_MSI_L1C")
         self.assertGreater(len(less_results), 0)
         self.assertLess(len(less_results), len(results))
 
-        result_with_name = self.fetch_results("/eodag/providers?keywords=peps")
+        result_with_name = await self.fetch_results("/eodag/providers?keywords=peps")
         self.assertEqual(len(result_with_name), 1)
         self.assertEqual(result_with_name[0]["provider"], "peps")
 
-        result_with_description = self.fetch_results("/eodag/providers?keywords=cop")
+        result_with_description = await self.fetch_results("/eodag/providers?keywords=cop")
         self.assertGreater(len(result_with_description), 2)
         providers = [r["provider"] for r in result_with_description]
         self.assertIn("cop_marine", providers)
 
-        no_result = self.fetch_results("/eodag/providers?product_type=foo")
+        no_result = await self.fetch_results("/eodag/providers?product_type=foo")
         self.assertEqual(len(no_result), 0)
 
-    def test_guess_product_types(self):
-        all_results = self.fetch_results("/eodag/guess-product-type")
+    @gen_test
+    async def test_guess_product_types(self):
+        all_results = await self.fetch_results("/eodag/guess-product-type")
         self.assertIn("S2_MSI_L1C", [pt["ID"] for pt in all_results])
 
-        one_provider_results = self.fetch_results("/eodag/guess-product-type?provider=creodias")
+        one_provider_results = await self.fetch_results("/eodag/guess-product-type?provider=creodias")
         self.assertLess(len(one_provider_results), len(all_results))
         self.assertIn("COP_DEM_GLO90_DGED", [pt["ID"] for pt in all_results])
 
-        one_result = self.fetch_results("/eodag/guess-product-type?keywords=S2_MSI_L1C")
+        one_result = await self.fetch_results("/eodag/guess-product-type?keywords=S2_MSI_L1C")
         self.assertEqual(len(one_result), 1)
         self.assertEqual(one_result[0]["ID"], "S2_MSI_L1C")
 
-        another_result = self.fetch_results("/eodag/guess-product-type?keywords=Sentinel2%20L1C")
+        another_result = await self.fetch_results("/eodag/guess-product-type?keywords=Sentinel2%20L1C")
         self.assertEqual(len(another_result), 1)
         self.assertEqual(another_result[0]["ID"], "S2_MSI_L1C")
 
-        more_results = self.fetch_results("/eodag/guess-product-type?keywords=Sentinel")
+        more_results = await self.fetch_results("/eodag/guess-product-type?keywords=Sentinel")
         self.assertGreater(len(more_results), 1)
         self.assertLess(len(more_results), len(all_results))
         self.assertIn("S2_MSI_L1C", [pt["ID"] for pt in more_results])
 
-        less_results = self.fetch_results("/eodag/guess-product-type?keywords=Sentinel&provider=peps")
+        less_results = await self.fetch_results("/eodag/guess-product-type?keywords=Sentinel&provider=peps")
         self.assertGreater(len(more_results), 1)
         self.assertLess(len(less_results), len(more_results))
         self.assertEqual(less_results[0]["ID"], "S1_SAR_GRD")
 
-        other_results = self.fetch_results("/eodag/guess-product-type?keywords=cop")
+        other_results = await self.fetch_results("/eodag/guess-product-type?keywords=cop")
         self.assertGreater(len(other_results), 1)
         self.assertLess(len(other_results), len(all_results))
         self.assertTrue(other_results[0]["ID"].lower().startswith("cop"))
 
-        self.fetch_results_error("/eodag/guess-product-type?provider=foo", 400)
+        await self.fetch_results_error("/eodag/guess-product-type?provider=foo", 400)
 
-    def test_get_not_found(self):
-        self.fetch_results_error("/eodag/foo", 404)
+    @gen_test
+    async def test_get_not_found(self):
+        await self.fetch_results_error("/eodag/foo", 404)
 
-    def test_post_not_found(self):
-        self.fetch_results_error("/eodag/foo/bar", 404, method="POST", body=json.dumps({}))
+    @gen_test
+    async def test_post_not_found(self):
+        await self.fetch_results_error("/eodag/foo/bar", 404, method="POST", body=json.dumps({}))
 
     @mock.patch(
         "eodag.api.core.EODataAccessGateway.search",
         autospec=True,
         return_value=SearchResult([], 0),
     )
-    def test_search(self, mock_search):
+    @gen_test
+    async def test_search(self, mock_search):
         geom_dict = {
             "type": "Polygon",
             "coordinates": [[[0, 2], [0, 3], [1, 3], [1, 2], [0, 2]]],
         }
         # full example
-        result = self.fetch_results(
+        result = await self.fetch_results(
             "/eodag/S2_MSI_L1C",
             method="POST",
             body=json.dumps(
@@ -207,7 +218,7 @@ class TestEodagLabExtensionHandler(AsyncHTTPTestCase):
 
         # minimal example
         mock_search.reset_mock()
-        result = self.fetch_results(
+        result = await self.fetch_results(
             "/eodag/S2_MSI_L1C",
             method="POST",
             body=json.dumps({}),
@@ -220,7 +231,7 @@ class TestEodagLabExtensionHandler(AsyncHTTPTestCase):
 
         # date error
         mock_search.reset_mock()
-        self.fetch_results_error(
+        await self.fetch_results_error(
             "/eodag/S2_MSI_L1C",
             400,
             method="POST",
@@ -229,7 +240,7 @@ class TestEodagLabExtensionHandler(AsyncHTTPTestCase):
 
         # geom error
         mock_search.reset_mock()
-        self.fetch_results_error(
+        await self.fetch_results_error(
             "/eodag/S2_MSI_L1C",
             400,
             method="POST",
@@ -241,8 +252,9 @@ class TestEodagLabExtensionHandler(AsyncHTTPTestCase):
         autospec=True,
         return_value=QueryablesDict(additional_properties=False),
     )
-    def test_queryables(self, mock_list_queryables):
-        results = self.fetch_results(
+    @gen_test
+    async def test_queryables(self, mock_list_queryables):
+        results = await self.fetch_results(
             "/eodag/queryables?"
             "provider=some_provider&productType=some_product_type"
             "&param1=paramValue1&param2=paramValue2"
@@ -258,13 +270,15 @@ class TestEodagLabExtensionHandler(AsyncHTTPTestCase):
             param2="paramValue2",
         )
 
-    def test_info(self):
-        infos = self.fetch_results("/eodag/info")
+    @gen_test
+    async def test_info(self):
+        infos = await self.fetch_results("/eodag/info")
         self.assertIn("packages", infos)
         self.assertEqual(infos["packages"]["eodag"]["version"], eodag_version)
         self.assertEqual(infos["packages"]["eodag_labextension"]["version"], labextension_version)
 
     @mock.patch.dict(os.environ, {"EODAG_LABEXTENSION__DEBUG": "true"})
-    def test_debug(self):
-        infos = self.fetch_results("/eodag/info")
+    @gen_test
+    async def test_debug(self):
+        infos = await self.fetch_results("/eodag/info")
         self.assertTrue(infos["debug"])


### PR DESCRIPTION
Fixes #171

Context

1. On the form that manages the providers and products lists, users were able to change values even while data was still loading. This could lead to unexpected behaviors if the timing was off.

Changes

1. Async backend API handlers to prevent UI to be blocked while init
2. Introduced two separate loading states for the fetchProducts and fetchProviders hooks.
3. Added a disabled state on the Autocomplete component by using the isDisabled prop from the react-select Async component.
4. Connected each hook’s loading state to its corresponding Autocomplete instance (providers and products).

How to test

- [x] Load the initial page that contains the Autocomplete components.
- [x] Change the provider value in the provider Autocomplete. The product Autocomplete should be disabled while providers are loading.
- [x] Change the product value in the product Autocomplete. The provider Autocomplete should be disabled while products are loading.