### PR TITLE
fix(form): Resets the optional parameters when an optional parameter is unchecked

### DIFF
--- a/src/formComponent/FormComponent.tsx
+++ b/src/formComponent/FormComponent.tsx
@@ -275,6 +275,7 @@ export const FormComponent: FC<IProps> = ({
       setSelectedOptions(
         selectedOptions.filter(option => option !== param.value)
       );
+      resetField(param.value);
     } else {
       setSelectedOptions([...selectedOptions, param.value]);
     }


### PR DESCRIPTION
Fixes #173

Context

1. In the form that manages providers, product lists, and optional parameters, when a user selects an optional parameter and assigns a value to it, unchecking that parameter does not remove its data from the form.

Changes

1. Added a resetField call to clear the optional parameter field, setting it to undefined so it is ignored on form submission.

How to test

- [x]     Load the initial page containing the form.
- [x]     Select any provider and any product, then click the "more parameters" button.
- [x]     Check any option from the list of optional parameters.
- [x]     Once checked, enter a value in the corresponding text input field.
- [x]     Open the "more parameters" menu again and uncheck the previously selected option.
- [x]     Submit the form.
- [x]     Verify that the unchecked parameter is no longer included in the submitted data.