### PR TITLE
feat: pydantic settings and info handler

### DIFF
--- a/eodag_labextension/config.py
+++ b/eodag_labextension/config.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# Copyright 2025 CS GROUP - France, http://www.c-s.fr
+# All rights reserved
+
+"""EODAG Labextension configuration"""
+
+from __future__ import annotations
+
+import re
+from importlib.metadata import distributions
+from typing import Optional
+
+from pydantic import BaseModel
+from pydantic_settings import BaseSettings
+
+
+class PackageInfo(BaseModel):
+    """Package info model"""
+
+    version: str
+
+
+def get_packages_infos(filter: Optional[str] = None) -> dict[str, PackageInfo]:
+    """Get packages infos"""
+    infos: dict[str, PackageInfo] = {}
+
+    pattern = re.compile(filter) if filter else None
+
+    installed_packages = distributions()
+    for package in installed_packages:
+        package_name = package.metadata["Name"]
+        if pattern is None or (pattern is not None and pattern.fullmatch(package_name)):
+            infos[package_name] = PackageInfo(version=package.version)
+    return infos
+
+
+class Settings(BaseSettings):
+    """EODAG Labextension config"""
+
+    debug: bool = False
+
+    packages: dict[str, PackageInfo] = get_packages_infos("^eodag.*$")

--- a/eodag_labextension/config.py
+++ b/eodag_labextension/config.py
@@ -11,7 +11,7 @@ from importlib.metadata import distributions
 from typing import Optional
 
 from pydantic import BaseModel
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class PackageInfo(BaseModel):
@@ -20,8 +20,8 @@ class PackageInfo(BaseModel):
     version: str
 
 
-def get_packages_infos(filter: Optional[str] = None) -> dict[str, PackageInfo]:
-    """Get packages infos"""
+def get_packages_info(filter: Optional[str] = None) -> dict[str, PackageInfo]:
+    """Get packages info"""
     infos: dict[str, PackageInfo] = {}
 
     pattern = re.compile(filter) if filter else None
@@ -37,6 +37,8 @@ def get_packages_infos(filter: Optional[str] = None) -> dict[str, PackageInfo]:
 class Settings(BaseSettings):
     """EODAG Labextension config"""
 
+    model_config = SettingsConfigDict(env_prefix="eodag_labextension__")
+
     debug: bool = False
 
-    packages: dict[str, PackageInfo] = get_packages_infos("^eodag.*$")
+    packages: dict[str, PackageInfo] = get_packages_info("^eodag.*$")

--- a/eodag_labextension/config.py
+++ b/eodag_labextension/config.py
@@ -6,11 +6,9 @@
 
 from __future__ import annotations
 
-import re
 from importlib.metadata import distributions
-from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, computed_field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -20,20 +18,6 @@ class PackageInfo(BaseModel):
     version: str
 
 
-def get_packages_info(filter: Optional[str] = None) -> dict[str, PackageInfo]:
-    """Get packages info"""
-    infos: dict[str, PackageInfo] = {}
-
-    pattern = re.compile(filter) if filter else None
-
-    installed_packages = distributions()
-    for package in installed_packages:
-        package_name = package.metadata["Name"]
-        if pattern is None or (pattern is not None and pattern.fullmatch(package_name)):
-            infos[package_name] = PackageInfo(version=package.version)
-    return infos
-
-
 class Settings(BaseSettings):
     """EODAG Labextension config"""
 
@@ -41,4 +25,14 @@ class Settings(BaseSettings):
 
     debug: bool = False
 
-    packages: dict[str, PackageInfo] = get_packages_info("^eodag.*$")
+    @computed_field
+    def packages(self) -> dict[str, PackageInfo]:
+        """Get packages info"""
+        infos: dict[str, PackageInfo] = {}
+
+        installed_packages = distributions()
+        for package in installed_packages:
+            package_name = package.metadata["Name"]
+            if package_name.startswith("eodag"):
+                infos[package_name] = PackageInfo(version=package.version)
+        return infos

--- a/eodag_labextension/handlers.py
+++ b/eodag_labextension/handlers.py
@@ -25,6 +25,8 @@ from jupyter_server.base.handlers import APIHandler
 from jupyter_server.utils import url_path_join
 from shapely.geometry import shape
 
+from eodag_labextension.config import Settings
+
 eodag_api = EODataAccessGateway()
 
 logger = logging.getLogger("eodag-labextension.handlers")
@@ -60,6 +62,15 @@ class ReloadHandler(APIHandler):
     def get(self):
         """Get endpoint"""
         eodag_api.__init__()
+
+
+class InfoHandler(APIHandler):
+    """EODAG info handler"""
+
+    @tornado.web.authenticated
+    def get(self):
+        """Get endpoint"""
+        self.write(orjson.dumps(Settings().model_dump()))
 
 
 class ProvidersHandler(APIHandler):
@@ -325,6 +336,7 @@ def setup_handlers(web_app, url_path):
     host_pattern = r".*$"
     product_types_pattern = url_path_join(base_url, url_path, "product-types")
     reload_pattern = url_path_join(base_url, url_path, "reload")
+    info_pattern = url_path_join(base_url, url_path, "info")
     providers_pattern = url_path_join(base_url, url_path, "providers")
     guess_product_types_pattern = url_path_join(base_url, url_path, "guess-product-type")
     queryables_pattern = url_path_join(base_url, url_path, "queryables")
@@ -338,6 +350,7 @@ def setup_handlers(web_app, url_path):
         (providers_pattern, ProvidersHandler),
         (guess_product_types_pattern, GuessProductTypeHandler),
         (queryables_pattern, QueryablesHandler),
+        (info_pattern, InfoHandler),
         (MethodAndPathMatch("POST", search_pattern), SearchHandler),
         (default_pattern, NotFoundHandler),
     ]

--- a/eodag_labextension/handlers.py
+++ b/eodag_labextension/handlers.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import orjson
 import tornado
-from eodag import EODataAccessGateway, SearchResult
+from eodag import EODataAccessGateway, SearchResult, setup_logging
 from eodag.api.core import DEFAULT_ITEMS_PER_PAGE, DEFAULT_PAGE
 from eodag.utils import parse_qs
 from eodag.utils.exceptions import (
@@ -30,6 +30,10 @@ from eodag_labextension.config import Settings
 eodag_api = EODataAccessGateway()
 
 logger = logging.getLogger("eodag-labextension.handlers")
+
+
+if Settings().debug:
+    setup_logging(3)
 
 
 class ProductTypeHandler(APIHandler):

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup_args = dict(
         "notebook>=6.0.3,<7.0.0",
         "eodag[notebook]>=3.1.0",
         "orjson",
+        "pydantic-settings",
     ],
     extras_require={
         "dev": [

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup_args = dict(
         "notebook>=6.0.3,<7.0.0",
         "eodag[notebook]>=3.1.0",
         "orjson",
+        "pydantic",
         "pydantic-settings",
     ],
     extras_require={

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -263,3 +263,8 @@ class TestEodagLabExtensionHandler(AsyncHTTPTestCase):
         self.assertIn("packages", infos)
         self.assertEqual(infos["packages"]["eodag"]["version"], eodag_version)
         self.assertEqual(infos["packages"]["eodag_labextension"]["version"], labextension_version)
+
+    @mock.patch.dict(os.environ, {"EODAG_LABEXTENSION__DEBUG": "true"})
+    def test_debug(self):
+        infos = self.fetch_results("/eodag/info")
+        self.assertTrue(infos["debug"])

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -7,6 +7,7 @@ import re
 from unittest import mock
 
 from eodag import SearchResult
+from eodag import __version__ as eodag_version
 from eodag.api.core import DEFAULT_ITEMS_PER_PAGE
 from eodag.types.queryables import QueryablesDict
 from notebook.notebookapp import NotebookApp
@@ -14,6 +15,7 @@ from shapely.geometry import shape
 from tornado.testing import AsyncHTTPTestCase
 from tornado.web import authenticated
 
+from eodag_labextension import __version__ as labextension_version
 from eodag_labextension import load_jupyter_server_extension
 from eodag_labextension.handlers import APIHandler
 
@@ -255,3 +257,9 @@ class TestEodagLabExtensionHandler(AsyncHTTPTestCase):
             param1="paramValue1",
             param2="paramValue2",
         )
+
+    def test_info(self):
+        infos = self.fetch_results("/eodag/info")
+        self.assertIn("packages", infos)
+        self.assertEqual(infos["packages"]["eodag"]["version"], eodag_version)
+        self.assertEqual(infos["packages"]["eodag_labextension"]["version"], labextension_version)


### PR DESCRIPTION
`pydantic-settings` usage and new `info` handler http://localhost:8888/eodag/info returning package settings & infos:

```json
{"debug":false,"packages":{"eodag_labextension":{"version":"5.0.0b1"},"eodag":{"version":"3.4.0"}}}
```