### PR TITLE
feat(user settings): Add user settings edition menu item button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,4 +131,4 @@ dmypy.json
 .venv/
 
 # EODAG local conf symlink
-.eodag
+eodag-config

--- a/eodag_labextension/handlers.py
+++ b/eodag_labextension/handlers.py
@@ -43,36 +43,36 @@ if Settings().debug:
 
 
 def set_conf_symlink(eodag_api):
-    """Check and create .eodag symlink to user conf directory"""
+    """Check and create eodag-config symlink to user conf directory"""
     try:
         userconf_env = os.getenv("EODAG_CFG_FILE")
         userconf_src = userconf_env or os.path.join(eodag_api.conf_dir, "eodag.yml")
         # check if exists
-        if os.path.islink(".eodag"):
-            userdir_dst = os.readlink(".eodag")
+        if os.path.islink("eodag-config"):
+            userdir_dst = os.readlink("eodag-config")
             if os.path.isdir(userdir_dst):
                 userconf_dst = os.path.join(userdir_dst, "eodag.yml")
                 if userconf_src == userconf_dst:
-                    logger.debug("Re-using existing .eodag symlink to user configuration")
+                    logger.debug("Re-using existing eodag-config symlink to user configuration")
                     return
         # remove existing
-        if os.path.islink(".eodag") or os.path.isfile(".eodag"):
-            logger.debug("remove existing .eodag symlink")
-            os.remove(".eodag")
-        if os.path.isdir(".eodag"):
-            logger.debug("remove existing .eodag directory")
-            shutil.rmtree(".eodag")
+        if os.path.islink("eodag-config") or os.path.isfile("eodag-config"):
+            logger.debug("remove existing eodag-config symlink")
+            os.remove("eodag-config")
+        if os.path.isdir("eodag-config"):
+            logger.debug("remove existing eodag-config directory")
+            shutil.rmtree("eodag-config")
 
         # create symlink
         if userconf_env:
-            logger.debug(f"Creating .eodag symlink to custom user configuration {userconf_env}")
-            os.mkdir(".eodag")
-            os.symlink(userconf_env, os.path.join(".eodag", "eodag.yml"))
+            logger.debug(f"Creating eodag-config symlink to custom user configuration {userconf_env}")
+            os.mkdir("eodag-config")
+            os.symlink(userconf_env, os.path.join("eodag-config", "eodag.yml"))
         else:
-            logger.debug("Creating .eodag symlink to user configuration")
-            os.symlink(eodag_api.conf_dir, ".eodag")
+            logger.debug("Creating eodag-config symlink to user configuration")
+            os.symlink(eodag_api.conf_dir, "eodag-config")
     except OSError as err:
-        logger.error("Could not create .eodag symlink to user configuration: " + str(err))
+        logger.error("Could not create eodag-config symlink to user configuration: " + str(err))
 
 
 async def get_eodag_api():

--- a/src/browser.tsx
+++ b/src/browser.tsx
@@ -93,9 +93,16 @@ export class EodagBrowser extends React.Component<IProps, IState> {
     // present in the ~/.config/eodag/eodag.yml
     const filePath = '/eodag-config/eodag.yml';
 
-    await this.props.commands.execute('docmanager:open', {
+    const widget = await this.props.commands.execute('docmanager:open', {
       path: filePath,
       factory: 'Editor'
+    });
+
+    const context = widget.context;
+
+    // Reload user settings when the file is changed
+    context.fileChanged.connect(() => {
+      this.reloadUserSettings();
     });
   };
 

--- a/src/browser.tsx
+++ b/src/browser.tsx
@@ -88,6 +88,17 @@ export class EodagBrowser extends React.Component<IProps, IState> {
     return true;
   };
 
+  handleOpenEodagConfig = async () => {
+    // File that uses a symbolic link to the eodag config file,
+    // present in the ~/.config/eodag/eodag.yml
+    const filePath = '/user-config/eodag.yml';
+
+    await this.props.commands.execute('docmanager:open', {
+      path: filePath,
+      factory: 'Editor'
+    });
+  };
+
   handleShowFeature = (features: any, openModal: boolean) => {
     this.setState({
       features,
@@ -318,6 +329,7 @@ export class EodagBrowser extends React.Component<IProps, IState> {
             </button>
             <OptionsMenuDropdown
               openSettings={this.handleOpenSettings}
+              openEodagConfigEditor={this.handleOpenEodagConfig}
               version={this.state.eodagVersion ?? 'Loading ...'}
               labExtensionVersion={
                 this.state.eodagLabExtensionVersion ?? 'Loading ...'

--- a/src/browser.tsx
+++ b/src/browser.tsx
@@ -89,8 +89,6 @@ export class EodagBrowser extends React.Component<IProps, IState> {
   };
 
   handleOpenEodagConfig = async () => {
-    // File that uses a symbolic link to the eodag config file,
-    // present in the ~/.config/eodag/eodag.yml
     const filePath = '/eodag-config/eodag.yml';
 
     const widget = await this.props.commands.execute('docmanager:open', {
@@ -100,8 +98,16 @@ export class EodagBrowser extends React.Component<IProps, IState> {
 
     const context = widget.context;
 
-    // Reload user settings when the file is changed
+    let isInitial = true;
+
     context.fileChanged.connect(() => {
+      if (isInitial) {
+        // Ignore the first change (on open)
+        isInitial = false;
+        return;
+      }
+
+      // Only called on subsequent file changes (i.e., saves)
       this.reloadUserSettings();
     });
   };

--- a/src/browser.tsx
+++ b/src/browser.tsx
@@ -91,7 +91,7 @@ export class EodagBrowser extends React.Component<IProps, IState> {
   handleOpenEodagConfig = async () => {
     // File that uses a symbolic link to the eodag config file,
     // present in the ~/.config/eodag/eodag.yml
-    const filePath = '/user-config/eodag.yml';
+    const filePath = '/.eodag/eodag.yml';
 
     await this.props.commands.execute('docmanager:open', {
       path: filePath,

--- a/src/browser.tsx
+++ b/src/browser.tsx
@@ -91,7 +91,7 @@ export class EodagBrowser extends React.Component<IProps, IState> {
   handleOpenEodagConfig = async () => {
     // File that uses a symbolic link to the eodag config file,
     // present in the ~/.config/eodag/eodag.yml
-    const filePath = '/.eodag/eodag.yml';
+    const filePath = '/eodag-config/eodag.yml';
 
     await this.props.commands.execute('docmanager:open', {
       path: filePath,

--- a/src/optionsDropdown.tsx
+++ b/src/optionsDropdown.tsx
@@ -3,6 +3,7 @@ import React, { useMemo, useState } from 'react';
 import { Divider, IconButton, Menu, MenuItem } from '@mui/material';
 // Icons
 import SettingsIcon from '@mui/icons-material/SettingsOutlined';
+import EditIcon from '@mui/icons-material/EditOutlined';
 import BookIcon from '@mui/icons-material/BookOutlined';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
@@ -19,12 +20,14 @@ export interface IOptionsMenuDropdownItems {
 
 interface IOptionsMenuDropdownProps {
   openSettings: () => void;
+  openEodagConfigEditor: () => void;
   version: string;
   labExtensionVersion: string;
 }
 
 export const OptionsMenuDropdown: React.FC<IOptionsMenuDropdownProps> = ({
   openSettings,
+  openEodagConfigEditor,
   version,
   labExtensionVersion
 }) => {
@@ -38,12 +41,12 @@ export const OptionsMenuDropdown: React.FC<IOptionsMenuDropdownProps> = ({
         icon: <SettingsIcon />,
         onClick: () => openSettings()
       },
-      // {
-      //   name: 'Edit EODAG user configuration',
-      //   icon: <EditIcon />,
-      //   type: 'onClick',
-      //   onClick: () => {}
-      // },
+      {
+        name: 'Edit EODAG user configuration',
+        icon: <EditIcon />,
+        type: 'onClick',
+        onClick: () => openEodagConfigEditor()
+      },
       {
         name: '',
         type: 'divider'

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -291,17 +291,17 @@ class TestEodagLabExtensionHandler(AsyncHTTPTestCase):
             custom_cfg_file = Path(tmpdir) / "foo.yml"
             custom_cfg_file.touch()
             custom_cfg_file_str = str(custom_cfg_file.absolute())
-            local_cfg_file = Path(".eodag") / "eodag.yml"
+            local_cfg_file = Path("eodag-config") / "eodag.yml"
 
             # custom config file
             with mock.patch.dict(os.environ, {"EODAG_CFG_FILE": custom_cfg_file_str}):
                 eodag_api = await get_eodag_api()
                 set_conf_symlink(eodag_api)
-                self.assertTrue(os.path.isdir(".eodag"))
+                self.assertTrue(os.path.isdir("eodag-config"))
                 self.assertTrue(os.path.islink(str(local_cfg_file)))
                 self.assertEqual(custom_cfg_file, Path(os.readlink(str(local_cfg_file))))
 
             # default config file
             set_conf_symlink(eodag_api)
-            self.assertTrue(os.path.islink(".eodag"))
-            self.assertEqual(Path(eodag_api.conf_dir) / "eodag.yml", Path(os.readlink(".eodag")) / "eodag.yml")
+            self.assertTrue(os.path.islink("eodag-config"))
+            self.assertEqual(Path(eodag_api.conf_dir) / "eodag.yml", Path(os.readlink("eodag-config")) / "eodag.yml")


### PR DESCRIPTION
Fixes #183 and updates #200

This merge request adds a new menu item to the existing dropdown menu, allowing users to edit the eodag.yml configuration file located at ./eodag-conf/eodag.yml. This file is a local directory symlink to [EODAG user configuration file](https://eodag.readthedocs.io/en/stable/getting_started_guide/configure.html#yaml-user-configuration-file).

Clicking the new menu item opens the JupyterLab text editor with this file, allowing users to modify their EODAG configuration directly.

EODAG environment is reloaded on file change.

![image](https://github.com/user-attachments/assets/d1f2c167-c730-47c1-8fea-4aabca2522f6)
