### PR TITLE
Feat(map settings): Add map settings from API

### DIFF
--- a/src/MapExtentComponent.tsx
+++ b/src/MapExtentComponent.tsx
@@ -7,7 +7,6 @@ import * as React from 'react';
 import { FeatureGroup, MapContainer, TileLayer } from 'react-leaflet';
 import { EditControl } from 'react-leaflet-draw';
 import { throttle } from 'lodash';
-import { EODAG_TILE_COPYRIGHT, EODAG_TILE_URL } from './config';
 import { IGeometry } from './types';
 import { LeafletMouseEvent } from 'leaflet';
 import { EodagWidget } from './widget';
@@ -16,7 +15,7 @@ import { IMapSettings } from './browser';
 export interface IProps {
   onChange: (value: IGeometry | undefined) => void;
   geometry: IGeometry | undefined;
-  mapSettings?: IMapSettings;
+  mapSettings: IMapSettings;
 }
 
 export interface IState {
@@ -90,7 +89,7 @@ export default class MapExtentComponent extends React.Component<
   }
 
   handleMapSettingsChange(
-    sender: EodagWidget,
+    _sender: EodagWidget,
     settings: { lat: number; lon: number; zoom: number }
   ) {
     const { lat, lon, zoom } = settings;
@@ -180,7 +179,6 @@ export default class MapExtentComponent extends React.Component<
     const { zoom, lat, lon } = this.state;
     const { mapSettings } = this.props;
     const position: [number, number] = [lat, lon];
-    console.log('mapSettings : ', mapSettings);
     return (
       <MapContainer
         center={position}
@@ -190,8 +188,8 @@ export default class MapExtentComponent extends React.Component<
         }}
       >
         <TileLayer
-          url={mapSettings?.url || EODAG_TILE_URL}
-          attribution={mapSettings?.attributions || EODAG_TILE_COPYRIGHT}
+          url={mapSettings.tile_url}
+          attribution={mapSettings.tile_attribution}
         />
         <FeatureGroup>
           <EditControl

--- a/src/MapExtentComponent.tsx
+++ b/src/MapExtentComponent.tsx
@@ -55,7 +55,7 @@ export default class MapExtentComponent extends React.Component<
     this.state = {
       lat: 46.8,
       lon: 1.8,
-      zoom: props.mapSettings?.zoomOffset || 4,
+      zoom: props.mapSettings?.zoom_offset || 4,
       geometry: props.geometry
     };
     this.handleMapSettingsChange = this.handleMapSettingsChange.bind(this);
@@ -178,6 +178,7 @@ export default class MapExtentComponent extends React.Component<
   render() {
     const { zoom, lat, lon } = this.state;
     const { mapSettings } = this.props;
+    const { tile_url, tile_attribution, zoom_offset } = mapSettings;
     const position: [number, number] = [lat, lon];
     return (
       <MapContainer
@@ -186,10 +187,12 @@ export default class MapExtentComponent extends React.Component<
         ref={ref => {
           this.map = ref;
         }}
+        minZoom={Math.abs(zoom_offset)}
       >
         <TileLayer
-          url={mapSettings.tile_url}
-          attribution={mapSettings.tile_attribution}
+          url={tile_url}
+          attribution={tile_attribution}
+          zoomOffset={zoom_offset}
         />
         <FeatureGroup>
           <EditControl

--- a/src/MapFeatureComponent.tsx
+++ b/src/MapFeatureComponent.tsx
@@ -4,10 +4,10 @@
  */
 
 import * as React from 'react';
-import { MapContainer, TileLayer, GeoJSON } from 'react-leaflet';
-import { isEmpty, get } from 'lodash';
-import { EODAG_TILE_URL, EODAG_TILE_COPYRIGHT } from './config';
+import { GeoJSON, MapContainer, TileLayer } from 'react-leaflet';
+import { get, isEmpty } from 'lodash';
 import L, { FeatureGroup, LeafletMouseEvent } from 'leaflet';
+import { IMapSettings } from './browser';
 
 export interface IProps {
   features: any;
@@ -15,6 +15,7 @@ export interface IProps {
   highlightFeature: any;
   handleHoverFeature: any;
   handleClickFeature: (productId: string) => void;
+  mapSettings: IMapSettings;
 }
 
 export interface IState {
@@ -27,21 +28,18 @@ export default class MapFeatureComponent extends React.Component<
   IProps,
   IState
 > {
-  /**
-   * Leaflet map object
-   */
-  map: any;
-
   static DEFAULT_EXTENT_STYLE = {
     color: '#3f51b5',
     fillOpacity: 0.01
   };
-
   static HIGHLIGHT_EXTENT_STYLE = {
     color: '#76ff03',
     fillOpacity: 0.01
   };
-
+  /**
+   * Leaflet map object
+   */
+  map: any;
   EditOptions = {
     polyline: false,
     polygon: false,
@@ -49,6 +47,7 @@ export default class MapFeatureComponent extends React.Component<
     marker: false,
     circlemarker: false
   };
+
   constructor(props: IProps) {
     super(props);
     const featureGeoJSONs = new window.L.GeoJSON(props.features.features);
@@ -152,6 +151,7 @@ export default class MapFeatureComponent extends React.Component<
 
   render() {
     const { bounds } = this.state;
+    const { mapSettings } = this.props;
     // make sure that bounds is a LatLngBounds object
     const corner1 = L.latLng(
       bounds.getSouthWest().lat,
@@ -169,7 +169,10 @@ export default class MapFeatureComponent extends React.Component<
           this.map = ref;
         }}
       >
-        <TileLayer url={EODAG_TILE_URL} attribution={EODAG_TILE_COPYRIGHT} />
+        <TileLayer
+          url={mapSettings.tile_url}
+          attribution={mapSettings.tile_attribution}
+        />
         {!isEmpty(this.props.features) ? (
           <GeoJSON
             key={`features-gson-${

--- a/src/MapFeatureComponent.tsx
+++ b/src/MapFeatureComponent.tsx
@@ -152,6 +152,7 @@ export default class MapFeatureComponent extends React.Component<
   render() {
     const { bounds } = this.state;
     const { mapSettings } = this.props;
+    const { tile_url, tile_attribution, zoom_offset } = mapSettings;
     // make sure that bounds is a LatLngBounds object
     const corner1 = L.latLng(
       bounds.getSouthWest().lat,
@@ -168,10 +169,12 @@ export default class MapFeatureComponent extends React.Component<
         ref={ref => {
           this.map = ref;
         }}
+        minZoom={Math.abs(zoom_offset)}
       >
         <TileLayer
-          url={mapSettings.tile_url}
-          attribution={mapSettings.tile_attribution}
+          url={tile_url}
+          attribution={tile_attribution}
+          zoomOffset={zoom_offset}
         />
         {!isEmpty(this.props.features) ? (
           <GeoJSON

--- a/src/ModalComponent.tsx
+++ b/src/ModalComponent.tsx
@@ -5,14 +5,15 @@
 
 import * as React from 'react';
 import 'react-datepicker/dist/react-datepicker.css';
-import { find, isEqual, get, isUndefined } from 'lodash';
+import { find, get, isEqual, isUndefined } from 'lodash';
 import Modal, { Styles } from 'react-modal';
 import MapFeatureComponent from './MapFeatureComponent';
 import BrowseComponent from './BrowseComponent';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTimes, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import { faSpinner, faTimes } from '@fortawesome/free-solid-svg-icons';
 import DescriptionProductComponent from './DescriptionProductComponent';
-import { Tooltip, PlacesType, VariantType } from 'react-tooltip';
+import { PlacesType, Tooltip, VariantType } from 'react-tooltip';
+import { IMapSettings } from './browser';
 
 const customStyles: Styles = {
   overlay: {
@@ -40,6 +41,7 @@ export interface IProps {
   features: any;
   isRetrievingMoreFeature: () => boolean;
   handleRetrieveMoreFeature: () => Promise<void>;
+  mapSettings: IMapSettings | undefined;
 }
 
 export interface IState {
@@ -54,6 +56,7 @@ export interface IState {
 function Transition(props: any) {
   return <div direction="up" {...props} />;
 }
+
 const tooltipDark: VariantType = 'dark';
 const tooltipBottom: PlacesType = 'bottom';
 
@@ -152,7 +155,8 @@ export default class ModalComponent extends React.Component<IProps, IState> {
       handleClose,
       isRetrievingMoreFeature,
       handleRetrieveMoreFeature,
-      handleGenerateQuery
+      handleGenerateQuery,
+      mapSettings
     } = this.props;
     const {
       zoomFeature,
@@ -178,13 +182,16 @@ export default class ModalComponent extends React.Component<IProps, IState> {
           </div>
           <div className="jp-EodagWidget-modal-container">
             <div className="jp-EodagWidget-product-wrapper">
-              <MapFeatureComponent
-                features={features}
-                zoomFeature={zoomFeature}
-                highlightFeature={highlightOnMapFeature}
-                handleHoverFeature={this.handleHoverMapFeature}
-                handleClickFeature={this.handleClickFeature}
-              />
+              {mapSettings && (
+                <MapFeatureComponent
+                  features={features}
+                  zoomFeature={zoomFeature}
+                  highlightFeature={highlightOnMapFeature}
+                  handleHoverFeature={this.handleHoverMapFeature}
+                  handleClickFeature={this.handleClickFeature}
+                  mapSettings={mapSettings}
+                />
+              )}
               <div className="jp-EodagWidget-browse-title">
                 {isRetrievingMoreFeature() ? (
                   <div

--- a/src/browser.tsx
+++ b/src/browser.tsx
@@ -30,8 +30,8 @@ export interface IProps {
 }
 
 export interface IMapSettings {
-  attributions: string;
-  url: string;
+  tile_attribution: string;
+  tile_url: string;
   zoomOffset: number;
 }
 
@@ -64,11 +64,7 @@ export class EodagBrowser extends React.Component<IProps, IState> {
       reloadIndicator: false,
       eodagVersion: undefined,
       eodagLabExtensionVersion: undefined,
-      mapSettings: {
-        zoomOffset: 0,
-        url: '',
-        attributions: ''
-      }
+      mapSettings: undefined
     };
     this.reloadUserSettings = this.reloadUserSettings.bind(this);
   }
@@ -77,13 +73,13 @@ export class EodagBrowser extends React.Component<IProps, IState> {
     fetch('/eodag/info')
       .then(res => res.json())
       .then(data => {
-        const { packages } = data;
+        const { packages, map } = data;
         if (packages) {
           this.setState({
             eodagVersion: packages.eodag.version || 'Unknown version',
             eodagLabExtensionVersion:
               packages.eodag_labextension.version || 'Unknown version',
-            mapSettings: packages.mapInfos
+            mapSettings: map
           });
         }
       })
@@ -384,6 +380,7 @@ export class EodagBrowser extends React.Component<IProps, IState> {
           handleGenerateQuery={this.handleGenerateQuery}
           isRetrievingMoreFeature={this.isRetrievingMoreFeature}
           handleRetrieveMoreFeature={this.handleRetrieveMoreFeature}
+          mapSettings={mapSettings}
         />
       </div>
     );

--- a/src/browser.tsx
+++ b/src/browser.tsx
@@ -29,6 +29,12 @@ export interface IProps {
   commands: any;
 }
 
+export interface IMapSettings {
+  attributions: string;
+  url: string;
+  zoomOffset: number;
+}
+
 export interface IState {
   features: any;
   openDialog: any;
@@ -39,6 +45,7 @@ export interface IState {
   reloadIndicator: boolean;
   eodagVersion?: string;
   eodagLabExtensionVersion?: string;
+  mapSettings?: IMapSettings;
 }
 
 const tooltipDark: VariantType = 'dark';
@@ -56,7 +63,12 @@ export class EodagBrowser extends React.Component<IProps, IState> {
       isLoading: false,
       reloadIndicator: false,
       eodagVersion: undefined,
-      eodagLabExtensionVersion: undefined
+      eodagLabExtensionVersion: undefined,
+      mapSettings: {
+        zoomOffset: 0,
+        url: '',
+        attributions: ''
+      }
     };
     this.reloadUserSettings = this.reloadUserSettings.bind(this);
   }
@@ -65,11 +77,15 @@ export class EodagBrowser extends React.Component<IProps, IState> {
     fetch('/eodag/info')
       .then(res => res.json())
       .then(data => {
-        this.setState({
-          eodagVersion: data?.packages.eodag.version || 'Unknown version',
-          eodagLabExtensionVersion:
-            data?.packages.eodag_labextension.version || 'Unknown version'
-        });
+        const { packages } = data;
+        if (packages) {
+          this.setState({
+            eodagVersion: packages.eodag.version || 'Unknown version',
+            eodagLabExtensionVersion:
+              packages.eodag_labextension.version || 'Unknown version',
+            mapSettings: packages.mapInfos
+          });
+        }
       })
       .catch(() => {
         this.setState({
@@ -316,7 +332,7 @@ export class EodagBrowser extends React.Component<IProps, IState> {
   };
 
   render() {
-    const { openDialog, features } = this.state;
+    const { openDialog, features, mapSettings } = this.state;
     return (
       <div className="jp-EodagWidget-products-search">
         <div className="jp-EodagWidget-header-wrapper">
@@ -359,6 +375,7 @@ export class EodagBrowser extends React.Component<IProps, IState> {
           handleGenerateQuery={this.handleGenerateQuery}
           reloadIndicator={this.state.reloadIndicator}
           onFetchComplete={this.resetIsLoading}
+          mapSettings={mapSettings}
         />
         <ModalComponent
           open={openDialog}

--- a/src/browser.tsx
+++ b/src/browser.tsx
@@ -32,7 +32,7 @@ export interface IProps {
 export interface IMapSettings {
   tile_attribution: string;
   tile_url: string;
-  zoomOffset: number;
+  zoom_offset: number;
 }
 
 export interface IState {

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,14 +4,14 @@
  */
 
 /**
- * Adress used to contact the EODAG server
+ * Address used to contact the EODAG server
  *
  * This is the notebook server REST API extension
  */
 export const EODAG_SERVER_ADRESS = 'eodag';
 
 /**
- * Adress used to retrieve tiles
+ * Address used to retrieve tiles
  */
 export const EODAG_TILE_URL =
   'https://a.tile.openstreetmap.org/{z}/{x}/{y}.png';
@@ -23,6 +23,6 @@ export const EODAG_TILE_COPYRIGHT =
   '&copy; <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors';
 
 /**
- * Adress used to contact the EODAG settings
+ * Address used to contact the EODAG settings
  */
 export const EODAG_SETTINGS_ADDRESS = 'api/settings/eodag-labextension:plugin';

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,18 +11,6 @@
 export const EODAG_SERVER_ADRESS = 'eodag';
 
 /**
- * Address used to retrieve tiles
- */
-export const EODAG_TILE_URL =
-  'https://a.tile.openstreetmap.org/{z}/{x}/{y}.png';
-
-/**
- * Copyright displayed on the map for accessing tiles
- */
-export const EODAG_TILE_COPYRIGHT =
-  '&copy; <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors';
-
-/**
  * Address used to contact the EODAG settings
  */
 export const EODAG_SETTINGS_ADDRESS = 'api/settings/eodag-labextension:plugin';

--- a/src/formComponent/FormComponent.tsx
+++ b/src/formComponent/FormComponent.tsx
@@ -306,20 +306,22 @@ export const FormComponent: FC<IProps> = ({
     <div className="jp-EodagWidget-wrapper">
       <FormProvider {...formInput}>
         <form onSubmit={handleSubmit(onSubmit)} className="jp-EodagWidget-form">
-          <div className="jp-EodagWidget-map">
-            <Controller
-              name="geometry"
-              control={control}
-              rules={{ required: false }}
-              render={({ field: { onChange, value } }) => (
-                <MapExtentComponent
-                  geometry={value}
-                  onChange={onChange}
-                  mapSettings={mapSettings}
-                />
-              )}
-            />
-          </div>
+          {mapSettings && (
+            <div className="jp-EodagWidget-map">
+              <Controller
+                name="geometry"
+                control={control}
+                rules={{ required: false }}
+                render={({ field: { onChange, value } }) => (
+                  <MapExtentComponent
+                    geometry={value}
+                    onChange={onChange}
+                    mapSettings={mapSettings}
+                  />
+                )}
+              />
+            </div>
+          )}
           <div className="jp-EodagWidget-field">
             <Controller
               name="provider"

--- a/src/formComponent/FormComponent.tsx
+++ b/src/formComponent/FormComponent.tsx
@@ -32,6 +32,7 @@ import { IFormInput, IOptionType, IParameter } from '../types';
 import AdditionalParameterFields from './AdditionalParameterFields';
 import ParameterGroup from './ParameterGroup';
 import DropdownButton from './DropdownButton';
+import { IMapSettings } from '../browser';
 
 export interface IProps {
   handleShowFeature: any;
@@ -40,6 +41,7 @@ export interface IProps {
   isNotebookCreated: any;
   reloadIndicator: boolean;
   onFetchComplete: () => void;
+  mapSettings?: IMapSettings;
 }
 
 export interface IOptionTypeBase {
@@ -66,7 +68,8 @@ export const FormComponent: FC<IProps> = ({
   handleGenerateQuery,
   isNotebookCreated,
   reloadIndicator,
-  onFetchComplete
+  onFetchComplete,
+  mapSettings
 }) => {
   const [productTypes, setProductTypes] = useState<IOptionTypeBase[]>();
   const [providers, setProviders] = useState<IOptionTypeBase[]>();
@@ -309,7 +312,11 @@ export const FormComponent: FC<IProps> = ({
               control={control}
               rules={{ required: false }}
               render={({ field: { onChange, value } }) => (
-                <MapExtentComponent geometry={value} onChange={onChange} />
+                <MapExtentComponent
+                  geometry={value}
+                  onChange={onChange}
+                  mapSettings={mapSettings}
+                />
               )}
             />
           </div>


### PR DESCRIPTION
Fixes #192 

This PR retrieves map settings (URL, attributions, and zoom offset) from the backend, allowing users to configure their own tile layer instead of relying on a fixed, hardcoded one.