### PR TITLE
refactor(handlers): do not return unnecessary product types fields

### DIFF
--- a/eodag_labextension/handlers.py
+++ b/eodag_labextension/handlers.py
@@ -226,12 +226,16 @@ class GuessProductTypeHandler(APIHandler):
             ):
                 # 1. List product types starting with given keywords
                 first_keyword = query_dict["keywords"][0].lower()
-                returned_product_types = [pt for pt in all_product_types if pt["ID"].lower().startswith(first_keyword)]
+                returned_product_types = [
+                    {"ID": pt["ID"], "title": pt.get("title")}
+                    for pt in all_product_types
+                    if pt["ID"].lower().startswith(first_keyword)
+                ]
                 returned_product_types_ids = [pt["ID"] for pt in returned_product_types]
 
                 # 2. List product types containing keyword
                 returned_product_types += [
-                    pt
+                    {"ID": pt["ID"], "title": pt.get("title")}
                     for pt in all_product_types
                     if first_keyword in pt["ID"].lower() and pt["ID"] not in returned_product_types_ids
                 ]
@@ -249,12 +253,12 @@ class GuessProductTypeHandler(APIHandler):
                 )
                 # product types with full associated metadata
                 returned_product_types += [
-                    pt
+                    {"ID": pt["ID"], "title": pt.get("title")}
                     for pt in all_product_types
                     if pt["ID"] in guessed_ids_list and pt["ID"] not in returned_product_types_ids
                 ]
             else:
-                returned_product_types = all_product_types
+                returned_product_types = [{"ID": pt["ID"], "title": pt.get("title")} for pt in all_product_types]
 
             self.finish(orjson.dumps(returned_product_types))
         except NoMatchingProductType:

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -127,33 +127,40 @@ class TestEodagLabExtensionHandler(AsyncHTTPTestCase):
     async def test_guess_product_types(self):
         all_results = await self.fetch_results("/eodag/guess-product-type")
         self.assertIn("S2_MSI_L1C", [pt["ID"] for pt in all_results])
+        self.assertListEqual(sorted(list(all_results[0].keys())), ["ID", "title"])
 
         one_provider_results = await self.fetch_results("/eodag/guess-product-type?provider=creodias")
         self.assertLess(len(one_provider_results), len(all_results))
         self.assertIn("COP_DEM_GLO90_DGED", [pt["ID"] for pt in all_results])
+        self.assertListEqual(sorted(list(one_provider_results[0].keys())), ["ID", "title"])
 
         one_result = await self.fetch_results("/eodag/guess-product-type?keywords=S2_MSI_L1C")
         self.assertEqual(len(one_result), 1)
         self.assertEqual(one_result[0]["ID"], "S2_MSI_L1C")
+        self.assertListEqual(sorted(list(one_result[0].keys())), ["ID", "title"])
 
         another_result = await self.fetch_results("/eodag/guess-product-type?keywords=Sentinel2%20L1C")
         self.assertEqual(len(another_result), 1)
         self.assertEqual(another_result[0]["ID"], "S2_MSI_L1C")
+        self.assertListEqual(sorted(list(another_result[0].keys())), ["ID", "title"])
 
         more_results = await self.fetch_results("/eodag/guess-product-type?keywords=Sentinel")
         self.assertGreater(len(more_results), 1)
         self.assertLess(len(more_results), len(all_results))
         self.assertIn("S2_MSI_L1C", [pt["ID"] for pt in more_results])
+        self.assertListEqual(sorted(list(more_results[0].keys())), ["ID", "title"])
 
         less_results = await self.fetch_results("/eodag/guess-product-type?keywords=Sentinel&provider=peps")
         self.assertGreater(len(more_results), 1)
         self.assertLess(len(less_results), len(more_results))
         self.assertEqual(less_results[0]["ID"], "S1_SAR_GRD")
+        self.assertListEqual(sorted(list(less_results[0].keys())), ["ID", "title"])
 
         other_results = await self.fetch_results("/eodag/guess-product-type?keywords=cop")
         self.assertGreater(len(other_results), 1)
         self.assertLess(len(other_results), len(all_results))
         self.assertTrue(other_results[0]["ID"].lower().startswith("cop"))
+        self.assertListEqual(sorted(list(other_results[0].keys())), ["ID", "title"])
 
         await self.fetch_results_error("/eodag/guess-product-type?provider=foo", 400)
 


### PR DESCRIPTION
Fixes https://github.com/CS-SI/eodag-labextension/issues/197

Do not return unnecessary product types fields. Response is now ~25x lighter