### PR TITLE
feat(settings): configurable map using environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,10 @@ EODAG Labextension can be configured using the following environment variables:
 - `EODAG_LABEXTENSION__DEBUG` (`bool`, default: `False`): whether to print
   [EODAG logging](https://eodag.readthedocs.io/en/stable/notebooks/api_user_guide/3_configuration.html#Logging) at DEBUG
   level or not.
-- `EODAG_LABEXTENSION__MAP__TILE_URL` (`str`|`None`, default: `None`): Map tile URL.
-- `EODAG_LABEXTENSION__MAP__TILE_COPYRIGHT` (`str`|`None`, default: `None`): Map tile copyright.
-- `EODAG_LABEXTENSION__MAP__ZOOM` (`int`|`None`, default: `None`): Map zoom level.
+- `EODAG_LABEXTENSION__MAP__TILE_URL` (`str`, default: `https://a.tile.openstreetmap.org/{z}/{x}/{y}.png`): Map tile URL.
+- `EODAG_LABEXTENSION__MAP__TILE_ATTRIBUTION` (`str`, default: "&copy; [OpenStreetMap](http://osm.org/copyright) contributors"):
+  Map tile attribution.
+- `EODAG_LABEXTENSION__MAP__ZOOM_OFFSET` (`int`, default: `0`): Map zoom offset.
 
 ## QuickStart
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Lab. The package consist of a Python Jupyter notebook REST service consumed by t
 - [Requirements](#requirements)
 - [Compatibility](#compatibility)
 - [Install](#install)
-  - [Configuration](#configuration)
+  - [System configuration](#system-configuration)
 - [QuickStart](#quickstart)
   - [Search](#search)
   - [Settings](#settings)
@@ -56,12 +56,16 @@ You can also uninstall it quite simply.
 pip uninstall eodag-labextension
 ```
 
-### Configuration
+### System configuration
 
-eodag configuration file should be localized at `~/.config/eodag/eodag.yaml` (see
-[eodag documentation](https://eodag.readthedocs.io/en/latest/getting_started_guide/configure.html)).
-Make sure that that file is configured properly.
-The file can directly be edited through [Settings menu](#settings).
+EODAG Labextension can be configured using the following environment variables:
+
+- `EODAG_LABEXTENSION__DEBUG` (`bool`, default: `False`): whether to print
+  [EODAG logging](https://eodag.readthedocs.io/en/stable/notebooks/api_user_guide/3_configuration.html#Logging) at DEBUG
+  level or not.
+- `EODAG_LABEXTENSION__MAP__TILE_URL` (`str`|`None`, default: `None`): Map tile URL.
+- `EODAG_LABEXTENSION__MAP__TILE_COPYRIGHT` (`str`|`None`, default: `None`): Map tile copyright.
+- `EODAG_LABEXTENSION__MAP__ZOOM` (`int`|`None`, default: `None`): Map zoom level.
 
 ## QuickStart
 
@@ -118,7 +122,7 @@ You will be enable to:
   - configure the default map settings.
 
 - Edit [EODAG user configuration file](https://eodag.readthedocs.io/en/stable/getting_started_guide/configure.html#yaml-user-configuration-file),
-  to set provider credentials, download directories, or other settings.
+  to set provider credentials, download directories, or other settings. Default file path is `~/.config/eodag/eodag.yaml`.
   EODAG environment automatically reloads on file save.
 - Open Labextension [Documentation](https://github.com/CS-SI/eodag-labextension/blob/develop/README.md),
   [Github repository](https://github.com/CS-SI/eodag-labextension), or [CS GROUP](https://www.cs-soprasteria.com) page.

--- a/eodag_labextension/config.py
+++ b/eodag_labextension/config.py
@@ -17,8 +17,8 @@ class MapInfo(BaseModel):
     """Map info model"""
 
     tile_url: Optional[str] = None
-    tile_copyright: Optional[str] = None
-    zoom: Optional[int] = None
+    tile_attribution: Optional[str] = None
+    zoom_offset: Optional[int] = None
 
 
 class PackageInfo(BaseModel):

--- a/eodag_labextension/config.py
+++ b/eodag_labextension/config.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 from importlib.metadata import distributions
-from typing import Optional
 
 from pydantic import BaseModel, computed_field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -16,9 +15,9 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class MapInfo(BaseModel):
     """Map info model"""
 
-    tile_url: Optional[str] = None
-    tile_attribution: Optional[str] = None
-    zoom_offset: Optional[int] = None
+    tile_url: str = "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png"
+    tile_attribution: str = "&copy; <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors"
+    zoom_offset: int = 0
 
 
 class PackageInfo(BaseModel):

--- a/eodag_labextension/config.py
+++ b/eodag_labextension/config.py
@@ -7,9 +7,18 @@
 from __future__ import annotations
 
 from importlib.metadata import distributions
+from typing import Optional
 
 from pydantic import BaseModel, computed_field
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class MapInfo(BaseModel):
+    """Map info model"""
+
+    tile_url: Optional[str] = None
+    tile_copyright: Optional[str] = None
+    zoom: Optional[int] = None
 
 
 class PackageInfo(BaseModel):
@@ -21,9 +30,11 @@ class PackageInfo(BaseModel):
 class Settings(BaseSettings):
     """EODAG Labextension config"""
 
-    model_config = SettingsConfigDict(env_prefix="eodag_labextension__")
+    model_config = SettingsConfigDict(env_prefix="eodag_labextension__", env_nested_delimiter="__")
 
     debug: bool = False
+
+    map: MapInfo = MapInfo()
 
     @computed_field
     def packages(self) -> dict[str, PackageInfo]:

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -292,6 +292,21 @@ class TestEodagLabExtensionHandler(AsyncHTTPTestCase):
         infos = await self.fetch_results("/eodag/info")
         self.assertTrue(infos["debug"])
 
+    @mock.patch.dict(
+        os.environ,
+        {
+            "EODAG_LABEXTENSION__MAP__TILE_URL": "http://foo.bar",
+            "EODAG_LABEXTENSION__MAP__TILE_COPYRIGHT": "Foo copyright",
+            "EODAG_LABEXTENSION__MAP__ZOOM": "2",
+        },
+    )
+    @gen_test
+    async def test_map_info(self):
+        infos = await self.fetch_results("/eodag/info")
+        self.assertEqual(infos["map"]["tile_url"], "http://foo.bar")
+        self.assertEqual(infos["map"]["tile_copyright"], "Foo copyright")
+        self.assertEqual(infos["map"]["zoom"], 2)
+
     @gen_test(timeout=120)
     async def test_set_conf_symlink(self):
         with TemporaryDirectory() as tmpdir:

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -296,16 +296,16 @@ class TestEodagLabExtensionHandler(AsyncHTTPTestCase):
         os.environ,
         {
             "EODAG_LABEXTENSION__MAP__TILE_URL": "http://foo.bar",
-            "EODAG_LABEXTENSION__MAP__TILE_COPYRIGHT": "Foo copyright",
-            "EODAG_LABEXTENSION__MAP__ZOOM": "2",
+            "EODAG_LABEXTENSION__MAP__TILE_ATTRIBUTION": "Foo attribution",
+            "EODAG_LABEXTENSION__MAP__ZOOM_OFFSET": "2",
         },
     )
     @gen_test
     async def test_map_info(self):
         infos = await self.fetch_results("/eodag/info")
         self.assertEqual(infos["map"]["tile_url"], "http://foo.bar")
-        self.assertEqual(infos["map"]["tile_copyright"], "Foo copyright")
-        self.assertEqual(infos["map"]["zoom"], 2)
+        self.assertEqual(infos["map"]["tile_attribution"], "Foo attribution")
+        self.assertEqual(infos["map"]["zoom_offset"], 2)
 
     @gen_test(timeout=120)
     async def test_set_conf_symlink(self):


### PR DESCRIPTION
Configurable map using environment variables:

- `EODAG_LABEXTENSION__MAP__TILE_URL` (`str`, default: `https://a.tile.openstreetmap.org/{z}/{x}/{y}.png`): Map tile URL.
- `EODAG_LABEXTENSION__MAP__TILE_ATTRIBUTION` (`str`, default: "&copy; <a href=http://osm.org/copyrigh>OpenStreetMap</a> contributors"): Map tile attribution.
- `EODAG_LABEXTENSION__MAP__ZOOM_OFFSET` (`int`, default: `0`): Map zoom offset.

Related to #192 , needed by #195