### PR TITLE
fix: requests using jupyterlab dedicated API

### DIFF
--- a/src/hooks/useEodagSettings.ts
+++ b/src/hooks/useEodagSettings.ts
@@ -10,9 +10,11 @@ export const useEodagSettings = () => {
       _serverSettings.appUrl,
       `${EODAG_SETTINGS_ADDRESS}`
     );
-    return fetch(URLExt.join(_eodag_settings), {
-      credentials: 'same-origin'
-    })
+    return ServerConnection.makeRequest(
+      URLExt.join(_eodag_settings),
+      {},
+      _serverSettings
+    )
       .then(res => {
         if (res.status !== 200) {
           throw new Error('Bad response from server');

--- a/src/hooks/useEodagVersions.ts
+++ b/src/hooks/useEodagVersions.ts
@@ -23,9 +23,11 @@ export const useEodagVersions = () => {
           serverSettings.baseUrl,
           EODAG_SERVER_ADDRESS
         );
-        const res = await fetch(URLExt.join(eodagServer, 'info'), {
-          credentials: 'same-origin'
-        });
+        const res = await ServerConnection.makeRequest(
+          URLExt.join(eodagServer, 'info'),
+          {},
+          serverSettings
+        );
 
         const contentType = res.headers.get('content-type');
         const isJson = contentType?.includes('application/json');

--- a/src/hooks/useUserSettings.ts
+++ b/src/hooks/useUserSettings.ts
@@ -18,9 +18,11 @@ export const useUserSettings = () => {
 
   const fetchUserSettings = async () => {
     try {
-      const response = await fetch(URLExt.join(eodagServer, 'reload'), {
-        credentials: 'same-origin'
-      });
+      const response = await ServerConnection.makeRequest(
+        URLExt.join(eodagServer, 'reload'),
+        {},
+        serverSettings
+      );
       if (!response.ok) {
         const msg = await response.json();
         throw {

--- a/src/utils/fetchers/fetchData.ts
+++ b/src/utils/fetchers/fetchData.ts
@@ -8,19 +8,23 @@ import { ICustomError } from '../../types';
 interface IFetchDataProps<T> {
   queryParams: string;
   onSuccess: (data: T[]) => Promise<IOptionTypeBase[]>;
+  init?: RequestInit;
 }
 
 export const fetchData = async <T>({
   queryParams,
-  onSuccess
+  onSuccess,
+  init = {}
 }: IFetchDataProps<T>): Promise<IOptionTypeBase[]> => {
   const serverSettings = ServerConnection.makeSettings();
   const eodagServer = URLExt.join(serverSettings.baseUrl, EODAG_SERVER_ADDRESS);
 
   try {
-    const response = await fetch(URLExt.join(eodagServer, queryParams), {
-      credentials: 'same-origin'
-    });
+    const response = await ServerConnection.makeRequest(
+      URLExt.join(eodagServer, queryParams),
+      init,
+      serverSettings
+    );
 
     const isJson = response.headers
       .get('content-type')

--- a/src/utils/searchService.ts
+++ b/src/utils/searchService.ts
@@ -85,26 +85,21 @@ class SearchService {
     const settings = await getEodagSettings();
     parameters.count = settings.searchCount;
 
-    const headers = new Headers({
-      'Content-Type': 'application/json'
-    });
+    const _serverSettings = ServerConnection.makeSettings();
 
-    // Set a cross-site cookie header
-    if (typeof document !== 'undefined' && document?.cookie) {
-      const xsrfToken = this.getCookie('_xsrf');
-      if (xsrfToken !== undefined) {
-        headers.append('X-XSRFToken', xsrfToken);
-      }
-    }
-
-    const request = new Request(url, {
-      credentials: 'same-origin',
+    const init = {
       method: 'POST',
       body: JSON.stringify(parameters),
-      headers: headers
-    });
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    };
 
-    const response = await fetch(request);
+    const response = await ServerConnection.makeRequest(
+      url,
+      init,
+      _serverSettings
+    );
     if (!response.ok) {
       const msg = await response.json();
       throw {


### PR DESCRIPTION
Send requests to the backend using `ServerConnection.makeRequest` from `jupyterlab/services` to avoid authentication errors