### PR TITLE
fix(handlers): utils.dates import

### DIFF
--- a/eodag_labextension/handlers.py
+++ b/eodag_labextension/handlers.py
@@ -19,6 +19,7 @@ import tornado
 from dotenv import dotenv_values
 from eodag import EODataAccessGateway, SearchResult, setup_logging
 from eodag.api.core import DEFAULT_ITEMS_PER_PAGE, DEFAULT_PAGE
+from eodag.utils.dates import get_datetime
 from eodag.utils.exceptions import (
     AuthenticationError,
     MisconfiguredError,
@@ -30,7 +31,6 @@ from eodag.utils.exceptions import (
     UnsupportedProvider,
     ValidationError,
 )
-from eodag.utils.dates import get_datetime
 from importlib_metadata import PackageNotFoundError, version
 from jupyter_server.base.handlers import APIHandler
 from jupyter_server.utils import url_path_join

--- a/eodag_labextension/handlers.py
+++ b/eodag_labextension/handlers.py
@@ -30,7 +30,7 @@ from eodag.utils.exceptions import (
     UnsupportedProvider,
     ValidationError,
 )
-from eodag.utils.rest import get_datetime
+from eodag.utils.dates import get_datetime
 from importlib_metadata import PackageNotFoundError, version
 from jupyter_server.base.handlers import APIHandler
 from jupyter_server.utils import url_path_join

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup_args = dict(
         "jupyterlab~=4.0",
         "tornado>=6.4.1,<7.0.0",
         "notebook>=6.0.3,<7.0.0",
-        "eodag[notebook]>=3.5.1",
+        "eodag[notebook]>=3.9.0",
         "orjson",
         "pydantic",
         "pydantic-settings",


### PR DESCRIPTION
Import date utils from `eodag.utils.dates` and update minimal version to `eodag >= 3.9.0`

Linked to : https://github.com/CS-SI/eodag/pull/1844