### PR TITLE
build: unpin eodag max version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup_args = dict(
         "jupyterlab~=4.0",
         "tornado>=6.4.1,<7.0.0",
         "notebook>=6.0.3,<7.0.0",
-        "eodag[notebook]==4.0.0a4",
+        "eodag[notebook]>=4.0.0a4",
         "orjson",
         "pydantic",
         "pydantic-settings",


### PR DESCRIPTION
unpin fixed eodag max version to `>=4.0.0a4`