### PR TITLE
refactor: adapt to eodag v4 changes

### DIFF
--- a/eodag_labextension/handlers.py
+++ b/eodag_labextension/handlers.py
@@ -241,20 +241,20 @@ class ProvidersHandler(APIHandler):
     async def get(self):
         """Get endpoint"""
 
-        available_providers_kwargs = []
+        available_providers_args = []
         query_dict = parse_qs(self.request.query)
 
         dag = await get_eodag_api()
 
         if isinstance(coll_list := query_dict.get("collection", []), list) and coll_list:
             try:
-                available_providers_kwargs.append(dag.get_collection_from_alias(coll_list[0]))
+                available_providers_args.append(dag.get_collection_from_alias(coll_list[0]))
             except NoMatchingCollection:
-                available_providers_kwargs.append(coll_list[0])
+                available_providers_args.append(coll_list[0])
 
         current_loop = asyncio.get_running_loop()
         available_providers = await current_loop.run_in_executor(
-            None, partial(dag.providers.filter, *available_providers_kwargs)
+            None, partial(dag.providers.filter, *available_providers_args)
         )
 
         all_providers_list = [

--- a/eodag_labextension/handlers.py
+++ b/eodag_labextension/handlers.py
@@ -17,7 +17,7 @@ import orjson
 import tornado
 from dotenv import dotenv_values
 from eodag import EODataAccessGateway, setup_logging
-from eodag.api.core import DEFAULT_ITEMS_PER_PAGE, DEFAULT_PAGE
+from eodag.api.core import DEFAULT_LIMIT, DEFAULT_PAGE
 from eodag.utils.dates import get_datetime
 from eodag.utils.exceptions import (
     AuthenticationError,
@@ -241,20 +241,20 @@ class ProvidersHandler(APIHandler):
     async def get(self):
         """Get endpoint"""
 
-        available_providers_kwargs = {}
+        available_providers_kwargs = []
         query_dict = parse_qs(self.request.query)
 
         dag = await get_eodag_api()
 
         if isinstance(coll_list := query_dict.get("collection", []), list) and coll_list:
             try:
-                available_providers_kwargs["collection"] = dag.get_collection_from_alias(coll_list[0])
+                available_providers_kwargs.append(dag.get_collection_from_alias(coll_list[0]))
             except NoMatchingCollection:
-                available_providers_kwargs["collection"] = coll_list[0]
+                available_providers_kwargs.append(coll_list[0])
 
         current_loop = asyncio.get_running_loop()
         available_providers = await current_loop.run_in_executor(
-            None, partial(dag.available_providers, **available_providers_kwargs)
+            None, partial(dag.providers.filter, *available_providers_kwargs)
         )
 
         all_providers_list = [
@@ -265,7 +265,7 @@ class ProvidersHandler(APIHandler):
                 url=provider.url,
             )
             for provider in dag.providers.values()
-            if provider in available_providers
+            if provider in available_providers.names
         ]
         all_providers_list.sort(key=lambda x: (x["priority"] * -1, x["provider"]))
 
@@ -407,7 +407,7 @@ class SearchHandler(APIHandler):
                 {
                     "properties": {
                         "page": page,
-                        "itemsPerPage": DEFAULT_ITEMS_PER_PAGE,
+                        "itemsPerPage": DEFAULT_LIMIT,
                         "totalResults": getattr(products, "number_matched", None),
                     }
                 }
@@ -418,7 +418,7 @@ class SearchHandler(APIHandler):
                 "features": [],
                 "properties": {
                     "page": 1,
-                    "itemsPerPage": DEFAULT_ITEMS_PER_PAGE,
+                    "itemsPerPage": DEFAULT_LIMIT,
                     "totalResults": 0,
                 },
             }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 dependencies = [
     "jupyterlab~=4.0",
     "tornado>=6.4.1,<7.0.0",
-    "eodag[notebook]>=4.0.0a4",
+    "eodag[notebook]~=4.0",
     "orjson",
     "pydantic",
     "pydantic-settings",

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -11,7 +11,7 @@ from unittest import mock
 
 from eodag import SearchResult
 from eodag import __version__ as eodag_version
-from eodag.api.core import DEFAULT_ITEMS_PER_PAGE
+from eodag.api.core import DEFAULT_LIMIT
 from eodag.types.queryables import QueryablesDict
 from jupyter_server.auth.identity import IdentityProvider, User
 from jupyter_server.serverapp import ServerApp
@@ -222,7 +222,7 @@ class TestEodagLabExtensionHandler(AsyncHTTPTestCase):
                 "features": [],
                 "properties": {
                     "page": 1,
-                    "itemsPerPage": DEFAULT_ITEMS_PER_PAGE,
+                    "itemsPerPage": DEFAULT_LIMIT,
                     "totalResults": 0,
                 },
             },
@@ -270,7 +270,6 @@ class TestEodagLabExtensionHandler(AsyncHTTPTestCase):
             "provider=some_provider&collection=some_collection"
             "&param1=paramValue1&param2=paramValue2"
         )
-        self.assertEqual(results["properties"], {})
         self.assertFalse(results["additionalProperties"])
         mock_list_queryables.assert_called_with(
             mock.ANY,


### PR DESCRIPTION
- change  `DEFAULT_ITEMS_PER_PAGE` to  `DEFAULT_LIMIT`
- remove deprecated `available_providers()`
- use `eodag[notebook]~=4.0` in dependencies