### PR TITLE
fix: reload providers list after configuration changes

### DIFF
--- a/src/components/browser.tsx
+++ b/src/components/browser.tsx
@@ -191,7 +191,9 @@ export const EodagBrowser: React.FC<IEodagBrowserProps> = ({
             openSettings={() =>
               commands.execute('settingeditor:open', { query: 'EODAG' })
             }
-            openEodagConfigEditor={() => handleOpenEodagConfig(commands)}
+            openEodagConfigEditor={() =>
+              handleOpenEodagConfig(commands, handleReload)
+            }
             version={eodagVersion ?? 'Loading ...'}
             labExtensionVersion={eodagLabExtensionVersion ?? 'Loading ...'}
           />

--- a/src/components/browser.tsx
+++ b/src/components/browser.tsx
@@ -48,6 +48,12 @@ export const EodagBrowser: React.FC<IEodagBrowserProps> = ({
     useEodagVersions();
   const { handleOpenEodagConfig, reloadUserSettings, isUserSettingsLoading } =
     useUserSettings();
+  const [providerRefreshKey, setProviderRefreshKey] = useState<number>(0);
+
+  const handleReload = async () => {
+    await reloadUserSettings();
+    setProviderRefreshKey(k => k + 1);
+  };
 
   const { formValues, form } = useProductsForm();
 
@@ -165,7 +171,7 @@ export const EodagBrowser: React.FC<IEodagBrowserProps> = ({
             <IconButton
               aria-label="Options"
               size="small"
-              onClick={reloadUserSettings}
+              onClick={handleReload}
               sx={{
                 color: '#000000'
               }}
@@ -201,6 +207,7 @@ export const EodagBrowser: React.FC<IEodagBrowserProps> = ({
         fetchProductsLoading={fetchProductLoading}
         fetchProviders={fetchProviders}
         fetchProvidersLoading={fetchProvidersLoading}
+        providerRefreshKey={providerRefreshKey}
       />
       <Modal
         open={openModal}

--- a/src/components/formComponent/formComponent.tsx
+++ b/src/components/formComponent/formComponent.tsx
@@ -45,6 +45,7 @@ export interface IFormComponentsProps {
   ) => Promise<IOptionTypeBase[]>;
   fetchProvidersLoading: boolean;
   fetchProductsLoading: boolean;
+  providerRefreshKey: number;
 }
 
 export interface IOptionTypeBase {
@@ -60,7 +61,8 @@ export const FormComponent: FC<IFormComponentsProps> = ({
   fetchProducts,
   fetchProviders,
   fetchProvidersLoading,
-  fetchProductsLoading
+  fetchProductsLoading,
+  providerRefreshKey
 }) => {
   const [collections, setCollections] = useState<IOptionTypeBase[]>();
   const [providers, setProviders] = useState<IOptionTypeBase[]>();
@@ -85,7 +87,7 @@ export const FormComponent: FC<IFormComponentsProps> = ({
   useEffect(() => {
     const fetchData = async () => await fetchProviders(collectionValue);
     fetchData().then(list => setProviders(list));
-  }, [collectionValue]);
+  }, [collectionValue, providerRefreshKey]);
 
   const onSubmit: SubmitHandler<IFormInput> = async data => {
     if (!openModal) {

--- a/src/hooks/useUserSettings.ts
+++ b/src/hooks/useUserSettings.ts
@@ -38,7 +38,10 @@ export const useUserSettings = () => {
     }
   };
 
-  const handleOpenEodagConfig = async (commands: CommandRegistry) => {
+  const handleOpenEodagConfig = async (
+    commands: CommandRegistry,
+    onAfterReload?: () => void
+  ) => {
     // File that uses a symbolic link to the eodag config file
     // present in the ~/.config/eodag/eodag.yml
     const filePath = '/eodag-config/eodag.yml';
@@ -60,7 +63,7 @@ export const useUserSettings = () => {
       }
 
       // Only called on subsequent file changes (i.e., saves)
-      reloadUserSettings();
+      reloadUserSettings().then(() => onAfterReload?.());
     });
   };
 


### PR DESCRIPTION
fixes #269

Reload providers list if `eodag.yml` configuration file gets edited from labextension UI