### PR TITLE
fix: single type usage for queryables

### DIFF
--- a/eodag_labextension/handlers.py
+++ b/eodag_labextension/handlers.py
@@ -485,6 +485,7 @@ class QueryablesHandler(APIHandler):
         }
         json_schema["properties"] = json_schema_properties
         self._remove_null_defaults(json_schema)
+        self._remove_anyof(json_schema, **queryables_kwargs)
         json_schema["additionalProperties"] = queryables_dict.additional_properties
         self.finish(json_schema)
 
@@ -492,6 +493,36 @@ class QueryablesHandler(APIHandler):
         for item in json_schema["properties"].values():
             if item.get("default") is None:
                 item.pop("default", None)
+
+    def _remove_anyof(self, json_schema: Any, **queryables_kwargs):
+        """Remove anyOf from json schema for better frontend compatibility.
+
+        Only keep the first non-null type.
+        """
+        anyofs = set()
+        for key, item in json_schema["properties"].items():
+            if key == "geometry":
+                # no need to handle geometry queryable
+                continue
+            if anyof := item.get("anyOf"):
+                item.pop("anyOf")
+                for anyof_item in anyof:
+                    if anyof_item.get("type") == "null":
+                        anyofs.add(key)
+                        break
+                non_null_anyof_item = next(i for i in anyof if i.get("type") != "null")
+                item.update(non_null_anyof_item)
+                logger.warning(
+                    "Only the first anyOf type (incompatible with frontend) kept for key %s: %s",
+                    key,
+                    non_null_anyof_item,
+                )
+        if anyofs:
+            logger.warning(
+                "Removed Optional type incompatible with frontend for key(s): (%s), on (%s)",
+                ", ".join(anyofs),
+                ", ".join(queryables_kwargs.values()),
+            )
 
 
 def setup_handlers(web_app, url_path):

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -6,6 +6,7 @@ import os
 import re
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Annotated, Any, Optional, Union
 from unittest import mock
 
 from eodag import SearchResult
@@ -14,6 +15,7 @@ from eodag.api.core import DEFAULT_ITEMS_PER_PAGE
 from eodag.types.queryables import QueryablesDict
 from jupyter_server.auth.identity import IdentityProvider, User
 from notebook.notebookapp import NotebookApp
+from pydantic.fields import Field
 from shapely.geometry import shape
 from tornado.httpclient import HTTPClientError
 from tornado.testing import AsyncHTTPTestCase, gen_test
@@ -278,6 +280,23 @@ class TestEodagLabExtensionHandler(AsyncHTTPTestCase):
             param1="paramValue1",
             param2="paramValue2",
         )
+
+    @mock.patch(
+        "eodag.api.core.EODataAccessGateway.list_queryables",
+        autospec=True,
+        return_value=QueryablesDict(
+            param_int=Annotated[int, Field(None)],
+            param_opt_str=Annotated[Optional[str], Field(None)],
+            param_union=Annotated[Union[dict[str, Any], str], Field(None)],
+        ),
+    )
+    @gen_test
+    async def test_queryables_values(self, mock_list_queryables):
+        results = await self.fetch_results("/eodag/queryables")
+        self.assertEqual(results["properties"]["param_int"]["type"], "integer")
+        self.assertEqual(results["properties"]["param_opt_str"]["type"], "string")
+        self.assertEqual(results["properties"]["param_union"]["type"], "object")
+        self.assertTrue(results["additionalProperties"])
 
     @gen_test
     async def test_info(self):


### PR DESCRIPTION
fixes #275

`anyOf`  is not supported by the frontend for queryables, remove it from queryables returned by the backend (keep the first non-null type)