### PR TITLE
build: move from NotebookApp to ServerApp and py312 support

### DIFF
--- a/jupyter-config/jupyter_notebook_config.d/eodag_labextension.json
+++ b/jupyter-config/jupyter_notebook_config.d/eodag_labextension.json
@@ -1,6 +1,6 @@
 {
-  "NotebookApp": {
-    "nbserver_extensions": {
+  "ServerApp": {
+    "jpserver_extensions": {
       "eodag_labextension": true
     }
   }

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,6 @@ setup_args = dict(
     install_requires=[
         "jupyterlab~=4.0",
         "tornado>=6.4.1,<7.0.0",
-        "notebook>=6.0.3,<7.0.0",
         "eodag[notebook]>=4.0.0a4",
         "orjson",
         "pydantic",
@@ -79,15 +78,18 @@ setup_args = dict(
     include_package_data=True,
     python_requires=">=3.9",
     platforms="Linux, Mac OS X, Windows",
-    keywords=["Jupyter", "JupyterLab", "JupyterLab3"],
+    keywords=["Jupyter", "JupyterLab", "JupyterLab4"],
+    license_expression="Apache-2.0",
     classifiers=[
-        "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Framework :: Jupyter",
+        "Framework :: Jupyter :: JupyterLab",
+        "Framework :: Jupyter :: JupyterLab :: 4",
     ],
 )
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -14,12 +14,11 @@ from eodag import __version__ as eodag_version
 from eodag.api.core import DEFAULT_ITEMS_PER_PAGE
 from eodag.types.queryables import QueryablesDict
 from jupyter_server.auth.identity import IdentityProvider, User
-from notebook.notebookapp import NotebookApp
+from jupyter_server.serverapp import ServerApp
 from pydantic.fields import Field
 from shapely.geometry import shape
 from tornado.httpclient import HTTPClientError
 from tornado.testing import AsyncHTTPTestCase, gen_test
-from tornado.web import authenticated
 
 from eodag_labextension import __version__ as labextension_version
 from eodag_labextension import load_jupyter_server_extension
@@ -27,6 +26,10 @@ from eodag_labextension.handlers import APIHandler, get_eodag_api, set_conf_syml
 
 
 class MockIdentityProvider(IdentityProvider):
+    """Identity provider that allows all requests without authentication."""
+
+    token = ""
+
     def get_user(self, handler):
         return User(username="test")
 
@@ -52,25 +55,22 @@ class TestEodagLabExtensionHandler(AsyncHTTPTestCase):
     def setUp(self):
         super().setUp()
         self.patcher_xsrf = mock.patch.object(APIHandler, "check_xsrf_cookie", return_value=None)
-        self.patcher_auth = mock.patch.object(authenticated, "__call__", return_value=lambda x: x)
         self.mock_xsrf = self.patcher_xsrf.start()
-        self.mock_auth = self.patcher_auth.start()
 
     def tearDown(self):
         super().tearDown()
         self.patcher_xsrf.stop()
-        self.patcher_auth.stop()
 
     def get_app(self):
-        # Create a new NotebookApp instance
-        app = NotebookApp()
+        # Create a new ServerApp instance (Notebook 7 / jupyter_server)
+        app = ServerApp()
         app.initialize(argv=[])
+
+        # Use MockIdentityProvider to bypass authentication in tests
+        app.web_app.settings["identity_provider"] = MockIdentityProvider(parent=app)
 
         # Load extension
         load_jupyter_server_extension(app)
-
-        # Use IdentityProvider instead of deprecated get_current_user override
-        app.web_app.settings["identity_provider"] = MockIdentityProvider()
 
         return app.web_app
 


### PR DESCRIPTION
Remove `notebook` dependency and move from `NotebookApp` to `jupyter_server` `ServerApp`.
Add missing  python 3.12 support